### PR TITLE
Fixed graphile-build link on index

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -137,7 +137,7 @@ const MyType =
 </div>
 
 <div class='flex'>
-<a class='strong-link' href='/postgraphile/'>More about Graphile Build <span class='fa fa-fw fa-long-arrow-right' /></a>
+<a class='strong-link' href='/graphile-build/'>More about Graphile Build <span class='fa fa-fw fa-long-arrow-right' /></a>
 </div>
 
 </div>


### PR DESCRIPTION
The link to more info on Graphile Build currently takes you to the wrong place so I've fixed it up, here's a screenshot of the offending link.
<img width="382" alt="graphile___powerful__extensible_and_performant_graphql_apis_rapidly" src="https://user-images.githubusercontent.com/4559119/31721216-afeeb526-b410-11e7-8198-d7e7abc8d0d8.png">
