### PR TITLE
Fix markdown formatting example for set_config

### DIFF
--- a/src/pages/postgraphile/security.md
+++ b/src/pages/postgraphile/security.md
@@ -57,7 +57,7 @@ specify a role.
 
 ### Generating JWTs
 
-PostGraphile also has support for generating JWTs easily from inside your 
+PostGraphile also has support for generating JWTs easily from inside your
 PostgreSQL schema.
 
 To do so we will take a composite type that you specify via
@@ -184,9 +184,13 @@ set local jwt.claims.user_id to '2';
 commit;
 ```
 
-_\* Actually to save roundtrips we perform just one query to set all configs
-via `select set_config('role', 'app_user', true), set_config('user_id', '2',
-true), ....`, but the `set local` is easier to understand)_
+> _Actually, to save roundtrips we perform just one query to set all configs
+via ..._
+```sql
+select set_config('role', 'app_user', true), set_config('user_id', '2',
+true), ...
+```
+ > _... but showing `set local` is simpler to understand._
 
 You can then access this information via `current_setting` (the second argument
 says it's okay for the property to be missing, but **only works in PostgreSQL
@@ -208,4 +212,3 @@ create policy update_if_author
   using ("userId" = current_user_id())
   with check ("userId" = current_user_id());
 ```
-


### PR DESCRIPTION
Before:

<img width="676" alt="screen shot 2018-01-23 at 1 02 03 pm" src="https://user-images.githubusercontent.com/6667096/35295099-de2d8fce-003d-11e8-80dc-8159b97d0358.png">

After:

<img width="883" alt="screen shot 2018-01-23 at 1 04 15 pm" src="https://user-images.githubusercontent.com/6667096/35295132-f03104e4-003d-11e8-8b09-29fc4ead6386.png">

Tested in latest FireFox and Chrome.

