### PR TITLE
Updated computed_columns.md & fix params/args

### DIFF
--- a/src/pages/postgraphile/computed-columns.md
+++ b/src/pages/postgraphile/computed-columns.md
@@ -83,7 +83,7 @@ returns setof my_schema.users as $$
 $$ language sql stable;
 ```
 
-You can also define parameters to your fields via your computed column function, and these will be exposed in the GraphQL schema as well:
+You can add parameters to your computed column field by declaring additional parameters in your PostgreSQL function:
 
 ```sql{1,4}
 -- Creates `User.greet(greeting: String!)` string field

--- a/src/pages/postgraphile/computed-columns.md
+++ b/src/pages/postgraphile/computed-columns.md
@@ -7,9 +7,11 @@ title: Computed Columns
 ## Computed Columns
 
 "Computed columns" add what appears to be an extra column (field) to the
-GraphQL table type, but unlike actual columns the value for this field is the
-result of calling a function. This function can accept additional arguments
-that influence its result, and can return a scalars, records, lists or sets.
+GraphQL table type, but, unlike an actual column, the value for this field is the result of 
+calling a function defined in the PostgreSQL schema.
+This function will automatically be exposed to the resultant GraphQL schema
+as a field on the type; it can accept arguments that influence its result,
+and may return either a scalar, record, list or a set.
 Sets (denoted by `RETURNS SETOF ...`) are exposed as
 [connections](/postgraphile/connections/).
 
@@ -21,7 +23,7 @@ it must obey the following rules:
 
 * adhere to [common PostGraphile function restrictions](/postgraphile/function-restrictions/)
 * name must begin with the name of the table it applies to, followed by an underscore (`_`)
-* first argument must be the table type
+* first parameter must be the table type
 * must NOT return `VOID`
 * must be marked as `STABLE` (or `IMMUTABLE`, though that tends to be less common)
 * must be defined in the same PostgreSQL schema as the table
@@ -81,13 +83,13 @@ returns setof my_schema.users as $$
 $$ language sql stable;
 ```
 
-You can also expose additional arguments via your computed column function, and these will be exposed via GraphQL:
+You can also define parameters to your fields via your computed column function, and these will be exposed in the GraphQL schema as well:
 
 ```sql{1,4}
 -- Creates `User.greet(greeting: String!)` string field
 create function my_schema.users_greet(
-  u my_schema.users,
-  greeting text
+  u my_schema.users,  --- required table type parameter, unexposed
+  greeting text       --- additional parameter, will be exposed
 ) returns varchar as $$
   select greeting || ', ' || u.first_name || ' ' || u.last_name || '!';
 $$ language sql stable strict;


### PR DESCRIPTION
Fixed grammar. Improved readability by added some details, including inline comments in the last example.

Fixed the use of ambiguous use of "arguments" to "parameters" where correct to disambiguate between the named _formal parameters_ defined in a function c.f. the values of the _actual arguments_ provided to it. 

Ref: 
- https://stackoverflow.com/a/1788926/2469559
- https://docs.microsoft.com/en-us/dotnet/visual-basic/programming-guide/language-features/procedures/differences-between-parameters-and-arguments
- https://stackoverflow.com/a/156859/2469559
