### PR TITLE
Document the option keys supported in .postgraphilerc.js.

### DIFF
--- a/src/pages/postgraphile/usage-cli.md
+++ b/src/pages/postgraphile/usage-cli.md
@@ -168,3 +168,54 @@ module.exports = {
   },
 };
 ```
+
+Here is the list of keys and their default values, or types, supported in the `options` object returned by `.postgraphilerc.js`.
+
+```
+  appendPlugins: <string>
+  bodySizeLimit: <string>
+  classicIds = false
+  clusterWorkers: <integer>
+  connection: <string>
+  cors= false
+  defaultRole: <string>
+  disableDefaultMutations = false
+  disableGraphiql = false
+  disableQueryLog: true/false
+  dynamicJson = false
+  enableQueryBatching: true/false
+  exportSchemaGraphql: <path string>
+  exportSchemaJson: <path string>
+  extendedErrors = []
+  graphiql = '/graphiql'
+  graphql = '/graphql'
+  host = 'localhost'
+  includeExtensionResources = false
+  jwtAudiences: <string>
+  jwtRole = ['role']
+  jwtSecret: <string>
+  jwtTokenIdentifier
+  jwtVerifyAlgorithms: <string>
+  jwtVerifyAudience: <string>
+  jwtVerifyClockTolerance: <number>
+  jwtVerifyId: <string>
+  jwtVerifyIgnoreExpiration: true/false
+  jwtVerifyIgnoreNotBefore: true/false
+  jwtVerifyIssuer: <string>
+  jwtVerifySubject: <string>
+  legacyJsonUuid: true/false
+  maxPoolSize: <number>
+  plugins: <string>
+  port = 5000
+  prependPlugins: <string>
+  readCache: <path string>
+  schema: <string>
+  secret: <string>
+  showErrorStack: true/false
+  simpleCollections: [omit|both|only]
+  skipPlugins: <string>
+  timeout: <number>
+  token: : <string>
+  watch: true/false
+  writeCache: <path string>
+  ```

--- a/src/pages/postgraphile/usage-cli.md
+++ b/src/pages/postgraphile/usage-cli.md
@@ -218,4 +218,6 @@ Here is the list of keys and their default values, or types, supported in the `o
   token: : <string>
   watch: true/false
   writeCache: <path string>
-  ```
+```
+
+Please note that this interface is deprecated and will be removed in v5 (but its replacement hasn't been built yet...). You're encouraged to use PostGraphile as a library rather than using a `.postgraphilerc.js`.


### PR DESCRIPTION
If merged, this commit appends an explanation of which keys are currently supported in `.postgraphilerc.js`.

I limited the list to the command line options that are enumerated earlier in this document.

The command line arguments, and their corresponding option keys, are sometimes different.  It took me awhile to sort this in my particular implementation.  I had to resort to reading the code to suss what `.postgraphilerc.js` option keys correspond to several of the command line options I needed.

This is now documented.