### PR TITLE
add a note regarding `defaultRole` privileges

### DIFF
--- a/src/pages/postgraphile/make-extend-schema-plugin.md
+++ b/src/pages/postgraphile/make-extend-schema-plugin.md
@@ -331,3 +331,5 @@ makeExtendSchemaPlugin(build => {
 
 Note that the `@pgField` directive here is necessary for PostGraphile to "look
 ahead" and determine what to request from the database.
+
+**NOTE**: if your `defaultRole` does not have privileges to insert data into your table you can define a `security definer` function and call it instead, see [Custom Mutations](https://www.graphile.org/postgraphile/custom-mutations/) for more details.

--- a/src/pages/postgraphile/make-extend-schema-plugin.md
+++ b/src/pages/postgraphile/make-extend-schema-plugin.md
@@ -332,4 +332,4 @@ makeExtendSchemaPlugin(build => {
 Note that the `@pgField` directive here is necessary for PostGraphile to "look
 ahead" and determine what to request from the database.
 
-**NOTE**: if your `defaultRole` does not have privileges to insert data into your table you can define a `security definer` function and call it instead, see [Custom Mutations](https://www.graphile.org/postgraphile/custom-mutations/) for more details.
+**NOTE**: Plugins access the database with the same privileges as everything else - they are subject to RLS/RBAC/etc. If your user does not have privileges to perform the action your plugin is attempting to achieve then you may need to create a companion database function that is marked as `SECURITY DEFINER` in order to perform the action with elevated privileges; alternatively you could just use this database function directly - see [Custom Mutations](/postgraphile/custom-mutations/) for more details.


### PR DESCRIPTION
in last example (`MyRegisterUserMutationPlugin`) client probably have `defaultRole` access, it might not be possible to `INSERT INTO` table because of DB security, added a note to clarify it.