### PR TITLE
Fix link to the PostGraphile project on GitHub

### DIFF
--- a/src/pages/contribute.mdx
+++ b/src/pages/contribute.mdx
@@ -36,7 +36,7 @@ import write from '$images/contributions/write.png';
 
 <div class='flex'>
 <a class='button--solid' href='https://patreon.com/benjie'>Sponsor PostGraphile <span class='fas fa-fw fa-external-link-square-alt' /></a>&nbsp;
-<a class='button--outline' href='https://github/graphile/postgraphile'>PostGraphile on Github <span class='fas fa-fw fa-external-link-square-alt' /></a>
+<a class='button--outline' href='https://github.com/graphile/postgraphile'>PostGraphile on Github <span class='fas fa-fw fa-external-link-square-alt' /></a>
 </div>
 
 </MarketingSection>


### PR DESCRIPTION
This tiny PR fixes the *PostGraphile on Github* button link (missing tld).