### PR TITLE
Improved custom subscription docs

### DIFF
--- a/src/pages/postgraphile/subscriptions.md
+++ b/src/pages/postgraphile/subscriptions.md
@@ -12,12 +12,18 @@ Subscriptions notify you when an event occurs on the server side.
 
 _This feature requires PostGraphile v4.4.0 or higher._
 
+### Introduction
+
 Pass `--subscriptions` (or `subscriptions: true`) to PostGraphile and we'll
 enhance GraphiQL with subscription capabilities and give your PostGraphile
-server the power of websocket communications; but you'll notice that your
+server the power of websocket communications. This will enable the websocket endpoint.
+
+Additionally, you'll have to add the [`@graphile/pg-pubsub` plugin](https://www.npmjs.com/package/@graphile/pg-pubsub). It's intended that you use this plugin as a provider of realtime data to other plugins which can use it to add subscription fields to your API. For example, this plugin will add the `@pgSubscriptions` directive to easily define your own subscriptions using LISTEN/NOTIFY with makeExtendSchemaPlugin; and adds the --simple-subscriptions feature which, when enabled, adds a simple listen subscription field to your GraphQL API. See below how to enable the plugin for each approach
+
+Finally, you'll notice that your
 schema still only has `query` and `mutation` types. To add subscriptions to
 your GraphQL schema you'll need a plugin to provide the relevant
-`subscription` fields - or you can write your own [with
+`subscription` fields (by extending the `Subscription` type)- or you can write your own [with
 `makeExtendSchemaPlugin`](/postgraphile/make-extend-schema-plugin/).
 
 The easiest way to get started is with Simple Subscriptions (see below) but
@@ -192,6 +198,71 @@ postgraphile \
   --subscriptions \
   -c mydb
 ```
+
+#### Enabling with an Express app
+
+When using PostGraphile as a library, you may enable Custom Subscriptions by
+passing the `pluginHook` with the `@graphile/pg-pubsub` plugin, setting `subscriptions:true`
+and adding your custom plugin.
+
+We emulate part of the Express stack, so if you require sessions you can pass
+additional Connect/Express middlewares (sorry, we don't support Koa middlewares
+here at this time) via the `websocketMiddlewares` option.
+
+Here's an example:
+
+```js
+const express = require("express");
+const { postgraphile, makePluginHook } = require("postgraphile");
+const MySubscriptionPlugin = require("./MySubscriptionPlugin"); // our plugin defined in previous step
+const { default: PgPubsub } = require("@graphile/pg-pubsub"); // rembember to install through yarn/npm
+
+const pluginHook = makePluginHook([PgPubsub]);
+
+const postgraphileOptions = {
+  pluginHook, // add the plugin hook. This will make the @pgSubscription avaiable in our schema definitions
+  subscriptions: true, // start the websocket server
+  websocketMiddlewares: [
+    // Add whatever middlewares you need here, note that they should only
+    // manipulate properties on req/res, they must not sent response data. e.g.:
+    //
+    //   require('express-session')(),
+    //   require('passport').initialize(),
+    //   require('passport').session(),
+  ],
+};
+
+const app = express();
+app.use(postgraphile(databaseUrl, "app_public", postgraphileOptions));
+app.listen(parseInt(process.env.PORT, 10) || 3000);
+```
+
+#### Testing your subscription with GraphiQL/GraphQL Playground
+To test your subscription you will need to first subscribe and then trigger it. 
+
+To subscribe, in one GraphiQL tab execute
+```gql
+subscription MySubscription {
+  currentUserUpdated {	
+    user
+    event
+  }
+}
+```
+You should get the answer: `"Waiting for subscription to yield data…"`
+
+To trigger the subscription, *in another GraphiQL tab* run a mutation that changes the user. This
+will depend on your implementation, for example:
+```gql
+mutation MyMutation {
+  updateUserById(input: {userPatch: {name: 'foo'}, id: ""}) {
+    clientMutationId
+  }
+}
+```
+In this tab you will get the regular mutation answer. Going back to the previous tab, 
+you will see the subscription paylod. You are good to go! This should
+serve as the basis to implement your own custom subscriptions.
 
 ---
 

--- a/src/pages/postgraphile/subscriptions.md
+++ b/src/pages/postgraphile/subscriptions.md
@@ -18,7 +18,7 @@ Pass `--subscriptions` (or `subscriptions: true`) to PostGraphile and we'll
 enhance GraphiQL with subscription capabilities and give your PostGraphile
 server the power of websocket communications. This will enable the websocket endpoint.
 
-Additionally, you'll have to add the [`@graphile/pg-pubsub` plugin](https://www.npmjs.com/package/@graphile/pg-pubsub). It's intended that you use this plugin as a provider of realtime data to other plugins which can use it to add subscription fields to your API. For example, this plugin will add the `@pgSubscriptions` directive to easily define your own subscriptions using LISTEN/NOTIFY with makeExtendSchemaPlugin; and adds the --simple-subscriptions feature which, when enabled, adds a simple listen subscription field to your GraphQL API. See below how to enable the plugin for each approach
+Although you can now use `makeExtendSchemaPlugin` to add your own subscription fields using your own realtime events, it's likely that you'll want to add the [`@graphile/pg-pubsub` realtime provider plugin](https://www.npmjs.com/package/@graphile/pg-pubsub) so that you can leverage PostgreSQL's built-in pubsub support. For example, this plugin will allow `makeExtendSchemaPlugin` to use the `@pgSubscriptions` directive to easily define your own subscriptions using PostgreSQL's `LISTEN`/`NOTIFY` (recommended for production). This plugin also adds the `--simple-subscriptions` flag that can be used to add a simple listen subscription field to your GraphQL API (useful for experimentation). See below how to enable the plugin for each approach.
 
 Finally, you'll notice that your
 schema still only has `query` and `mutation` types. To add subscriptions to

--- a/src/pages/postgraphile/subscriptions.md
+++ b/src/pages/postgraphile/subscriptions.md
@@ -202,7 +202,7 @@ postgraphile \
 #### Enabling with an Express app
 
 When using PostGraphile as a library, you may enable Custom Subscriptions by
-passing the `pluginHook` with the `@graphile/pg-pubsub` plugin, setting `subscriptions:true`
+passing the `pluginHook` with the `@graphile/pg-pubsub` plugin, setting `subscriptions: true`
 and adding your custom plugin.
 
 We emulate part of the Express stack, so if you require sessions you can pass

--- a/src/pages/postgraphile/subscriptions.md
+++ b/src/pages/postgraphile/subscriptions.md
@@ -255,7 +255,7 @@ To trigger the subscription, *in another GraphiQL tab* run a mutation that chang
 will depend on your implementation, for example:
 ```gql
 mutation MyMutation {
-  updateUserById(input: {userPatch: {name: 'foo'}, id: ""}) {
+  updateUserById(input: {userPatch: {name: "foo"}, id: 27}) {
     clientMutationId
   }
 }

--- a/src/pages/postgraphile/subscriptions.md
+++ b/src/pages/postgraphile/subscriptions.md
@@ -21,7 +21,7 @@ server the power of websocket communications. This will enable the websocket end
 Although you can now use `makeExtendSchemaPlugin` to add your own subscription fields using your own realtime events, it's likely that you'll want to add the [`@graphile/pg-pubsub` realtime provider plugin](https://www.npmjs.com/package/@graphile/pg-pubsub) so that you can leverage PostgreSQL's built-in pubsub support. For example, this plugin will allow `makeExtendSchemaPlugin` to use the `@pgSubscriptions` directive to easily define your own subscriptions using PostgreSQL's `LISTEN`/`NOTIFY` (recommended for production). This plugin also adds the `--simple-subscriptions` flag that can be used to add a simple listen subscription field to your GraphQL API (useful for experimentation). See below how to enable the plugin for each approach.
 
 If you just use the `--subscriptions` flag alone, you'll notice that your
-schema still only has `query` and `mutation` types. To add subscriptions to
+schema still only has `query` and `mutation` operation types. To add subscriptions to
 your GraphQL schema you'll need a plugin to provide the relevant
 `subscription` fields (by extending the `Subscription` type) - or you can write your own [with
 `makeExtendSchemaPlugin`](/postgraphile/make-extend-schema-plugin/).

--- a/src/pages/postgraphile/subscriptions.md
+++ b/src/pages/postgraphile/subscriptions.md
@@ -20,7 +20,7 @@ server the power of websocket communications. This will enable the websocket end
 
 Although you can now use `makeExtendSchemaPlugin` to add your own subscription fields using your own realtime events, it's likely that you'll want to add the [`@graphile/pg-pubsub` realtime provider plugin](https://www.npmjs.com/package/@graphile/pg-pubsub) so that you can leverage PostgreSQL's built-in pubsub support. For example, this plugin will allow `makeExtendSchemaPlugin` to use the `@pgSubscriptions` directive to easily define your own subscriptions using PostgreSQL's `LISTEN`/`NOTIFY` (recommended for production). This plugin also adds the `--simple-subscriptions` flag that can be used to add a simple listen subscription field to your GraphQL API (useful for experimentation). See below how to enable the plugin for each approach.
 
-Finally, you'll notice that your
+If you just use the `--subscriptions` flag alone, you'll notice that your
 schema still only has `query` and `mutation` types. To add subscriptions to
 your GraphQL schema you'll need a plugin to provide the relevant
 `subscription` fields (by extending the `Subscription` type)- or you can write your own [with

--- a/src/pages/postgraphile/subscriptions.md
+++ b/src/pages/postgraphile/subscriptions.md
@@ -23,7 +23,7 @@ Although you can now use `makeExtendSchemaPlugin` to add your own subscription f
 If you just use the `--subscriptions` flag alone, you'll notice that your
 schema still only has `query` and `mutation` types. To add subscriptions to
 your GraphQL schema you'll need a plugin to provide the relevant
-`subscription` fields (by extending the `Subscription` type)- or you can write your own [with
+`subscription` fields (by extending the `Subscription` type) - or you can write your own [with
 `makeExtendSchemaPlugin`](/postgraphile/make-extend-schema-plugin/).
 
 The easiest way to get started is with Simple Subscriptions (see below) but

--- a/src/pages/postgraphile/subscriptions.md
+++ b/src/pages/postgraphile/subscriptions.md
@@ -261,7 +261,7 @@ mutation MyMutation {
 }
 ```
 In this tab you will get the regular mutation answer. Going back to the previous tab, 
-you will see the subscription paylod. You are good to go! This should
+you will see the subscription payload. You are good to go! This should
 serve as the basis to implement your own custom subscriptions.
 
 ---


### PR DESCRIPTION
- Added explicit mention to @graphile/pg-pubsub requirements in the intro
- Added "Enabling with express app" for Custom subscriptions
- Added "How to test subscriptions with Graphiql" for newbies like me