### PR TITLE
`jwtRole` needs to be an array?

### DIFF
--- a/src/pages/postgraphile/usage-library.md
+++ b/src/pages/postgraphile/usage-library.md
@@ -113,7 +113,7 @@ The `postgraphile` middleware factory function takes three arguments, all of whi
   - `enableQueryBatching`: [Experimental] Enable the middleware to process multiple GraphQL queries in one request.
   - `jwtSecret`: The secret for your JSON web tokens. This will be used to verify tokens in the `Authorization` header, and signing JWT tokens you return in procedures.
   - `jwtVerifyOptions`: Options with which to perform JWT verification - see https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback If 'audience' property is unspecified, it will default to ['postgraphile']; to prevent audience verification set it explicitly to null.
-  - `jwtRole`: A comma separated list of strings that give a path in the jwt from which to extract the postgres role. If none is provided it will use the key `role` on the root of the jwt.
+  - `jwtRole`: An array of strings that give a path in the jwt from which to extract the postgres role. If none is provided it will use the key `role` on the root of the jwt.
   - `jwtPgTypeIdentifier`: The Postgres type identifier for the compound type which will be signed as a JWT token if ever found as the return type of a procedure. Can be of the form: `my_schema.my_type`. You may use quotes as needed: `"my-special-schema".my_type`.
   - `jwtAudiences`: [DEPRECATED] The audience to use when verifing the JWT token. Deprecated, use `jwtVerifyOptions.audience` instead.
   - `legacyRelations`: Some one-to-one relations were previously detected as one-to-many - should we export 'only' the old relation shapes, both new and old but mark the old ones as 'deprecated' (default), or 'omit' (recommended) the old relation shapes entirely.


### PR DESCRIPTION
I found a clue tucked away in the [Troubleshooting](https://github.com/graphile/postgraphile/blob/master/TROUBLESHOOTING.md#using-jwts) guide... it refers to using Express, but it seems it needs to be an array even if you're not using Express?