### PR TITLE
Use the given `tableAlias` variable

### DIFF
--- a/src/pages/postgraphile/subscriptions.md
+++ b/src/pages/postgraphile/subscriptions.md
@@ -96,7 +96,7 @@ module.exports = makeExtendSchemaPlugin(({ pgSql: sql }) => ({
           sql.fragment`app_public.users`,
           (tableAlias, sqlBuilder) => {
             sqlBuilder.where(
-              sql.fragment`${sqlBuilder.getTableAlias()}.id = ${sql.value(
+              sql.fragment`${tableAlias}.id = ${sql.value(
                 event.subject
               )}`
             );


### PR DESCRIPTION
... instead of calling a method on `sqlBuilder`. A trivial change/improvement, I'm just trying out the work flow x)