### PR TITLE
Homepage: Update to include Starter on homepage

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -73,15 +73,12 @@ class='mw5 pt4'
 <Col span="6">
 <MarketingProduct
 big
-name="Graphile Engine"
-headline="Build high-performance easily-extensible GraphQL schemas by combining plugins"
-docs="/graphile-build/getting-started/"
-more="/graphile-build/"
+name="Graphile Starter"
+headline="A quick-start project for full-stack application development in React, Node.js, GraphQL and PostgreSQL"
+more="https://github.com/graphile/starter"
 >
 
-Graphile Engine is the database-independent heart of PostGraphile — it's an
-extremely powerful way to build extensible automatic GraphQL APIs over any
-data source.
+Graphile Starter includes the foundations of a modern web application, with a full user registration system, session management, optimised job queue, pre-configured tooling, tests and much more.
 
 </MarketingProduct>
 </Col>

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -57,8 +57,41 @@ import COLOURS from "$components/colours";
 
 <MarketingDivide from="white" to="medium" via="light" down />
 
-
 <MarketingSection bg="medium">
+
+
+<Flex>
+<Col span="6">
+
+<img
+src="/images/graphile.optimized.svg"
+alt="Graphile Heart"
+class='mw5 pt4'
+/>
+
+</Col>
+<Col span="6">
+<MarketingProduct
+big
+name="Graphile Engine"
+headline="Build high-performance easily-extensible GraphQL schemas by combining plugins"
+docs="/graphile-build/getting-started/"
+more="/graphile-build/"
+>
+
+Graphile Engine is the database-independent heart of PostGraphile — it's an
+extremely powerful way to build extensible automatic GraphQL APIs over any
+data source.
+
+</MarketingProduct>
+</Col>
+</Flex>
+
+
+</MarketingSection>
+<MarketingDivide from="medium" to="dark" via="light" down/>
+
+<MarketingSection bg="dark">
 
 ## Database tools
 
@@ -92,7 +125,7 @@ Experimental, being developed in the open. Focusses on fast iteration speed.
 
 </MarketingSection>
 
-<MarketingDivide from="medium" to="light" down />
+<MarketingDivide from="dark" to="light" down />
 
 <MarketingSection bg="light">
 


### PR DESCRIPTION
New section under main PostGraphile banner for Graphile Starter:

<img width="1073" alt="Screenshot 2019-12-10 at 14 53 28" src="https://user-images.githubusercontent.com/6413628/70540564-634b2900-1b5d-11ea-9667-f975b058435e.png">
