### PR TITLE
Update requirements.md

### DIFF
--- a/src/pages/postgraphile/requirements.md
+++ b/src/pages/postgraphile/requirements.md
@@ -64,7 +64,7 @@ features.
 ### PostgreSQL: use latest
 
 For best results we recommend you use the latest stable release of PostgreSQL that we officially support
-(v11 at time of writing), however it should run well on 9.6 or higher and
+(v12 at time of writing), however it should run well on 9.6 or higher and
 anything that breaks v9.6 support will be deemed a breaking change. The
 absolute earliest version it will run well against is v9.4, however we do not
 support this version officially - we strongly recommend you upgrade.
@@ -100,9 +100,9 @@ we have preliminary support for.
 
 Works well.
 
-#### PG 12 [not officially supported _yet_, but works]
+#### PG 12 [officially supported]
 
-Seems to work.
+Works well.
 
 ### Operating system
 


### PR DESCRIPTION
Updating since postgreSQL v12 is the current version and is supported by PostGraphile.
According to Quick Start Guide, v9.6 is still supported.