### PR TITLE
Improve formatting of guides to run PostGraphile in Docker

### DIFF
--- a/src/pages/postgraphile/custom-mutations.md
+++ b/src/pages/postgraphile/custom-mutations.md
@@ -63,7 +63,12 @@ Notes on the above function:
 
 - `STRICT` is optional, it means that if any of the arguments are null then the
   mutation will not be called (and will thus return null with no error) - this
-  allows us to mark `teamId` as a required argument.
+  allows us to mark `teamId` as a required argument. If PostGraphile is run as a
+  library with the option `pgStrictFunctions: true`, argument without default
+  value will be marked mandatory whil arguments with default value will be
+  optional. For example:
+  `CREATE FUNCTION foo(a int, b int, c int = 0, d int = null)...` would give a
+  mutation `foo(a: Int!, b: Int!, c: Int, d: Int)`.
 - `SECURITY INVOKER` is the default, it means the function will run with the
   _security_ of the person who _invoked_ the function
 - `SECURITY DEFINER` means that the function will run with the _security_ of the

--- a/src/pages/postgraphile/custom-mutations.md
+++ b/src/pages/postgraphile/custom-mutations.md
@@ -63,12 +63,7 @@ Notes on the above function:
 
 - `STRICT` is optional, it means that if any of the arguments are null then the
   mutation will not be called (and will thus return null with no error) - this
-  allows us to mark `teamId` as a required argument. If PostGraphile runs as a
-  library with the option `pgStrictFunctions: true`, arguments without default
-  value will be set mandatory while arguments with default value will be
-  optional. For example:
-  `CREATE FUNCTION foo(a int, b int, c int = 0, d int = null)...` would give a
-  mutation `foo(a: Int!, b: Int!, c: Int, d: Int)`.
+  allows us to mark `teamId` as a required argument.
 - `SECURITY INVOKER` is the default, it means the function will run with the
   _security_ of the person who _invoked_ the function
 - `SECURITY DEFINER` means that the function will run with the _security_ of the
@@ -80,6 +75,27 @@ Notes on the above function:
   in a more familiar language you can use `LANGUAGE plv8` (JavaScript, requires
   extension), or one of the built in `LANGUAGE` options such as Python, Perl or
   Tcl
+
+If you'd like PostGraphile to treat all function arguments as required (non-null) 
+unless they have a default then you can use the `graphileBuildOptions.pgStrictFunctions = true`
+setting. This is similar to marking the function as `STRICT` but with the subtle difference that
+arguments with defaults may be specified as `NULL` without necessitating that the function returns
+null. With this setting enabled, arguments without default
+value will be set mandatory while arguments with default value will be
+optional. For example:
+`CREATE FUNCTION foo(a int, b int, c int = 0, d int = null)...` would give a
+mutation `foo(a: Int!, b: Int!, c: Int, d: Int)`. To set this in the library version,
+pass it as part of `graphileBuildOptions`:
+
+```js
+app.use(postgraphile(connectionString, schemaName, {
+  graphileBuildOptions: {
+    pgStrictFunctions: true
+  }
+}));
+```
+
+To use it with the CLI you need to do similar using the `.postgraphilerc.js` file.
 
 A note on **named types**: if you have a function that
 `RETURNS SETOF table(a int, b text)` then PostGraphile will not _currently_ pick

--- a/src/pages/postgraphile/custom-mutations.md
+++ b/src/pages/postgraphile/custom-mutations.md
@@ -63,9 +63,9 @@ Notes on the above function:
 
 - `STRICT` is optional, it means that if any of the arguments are null then the
   mutation will not be called (and will thus return null with no error) - this
-  allows us to mark `teamId` as a required argument. If PostGraphile is run as a
-  library with the option `pgStrictFunctions: true`, argument without default
-  value will be marked mandatory whil arguments with default value will be
+  allows us to mark `teamId` as a required argument. If PostGraphile runs as a
+  library with the option `pgStrictFunctions: true`, arguments without default
+  value will be set mandatory while arguments with default value will be
   optional. For example:
   `CREATE FUNCTION foo(a int, b int, c int = 0, d int = null)...` would give a
   mutation `foo(a: Int!, b: Int!, c: Int, d: Int)`.

--- a/src/pages/postgraphile/running-postgraphile-as-a-library-in-docker.md
+++ b/src/pages/postgraphile/running-postgraphile-as-a-library-in-docker.md
@@ -10,7 +10,7 @@ It is following the same use case as the guide **[Running PostGraphile in Docker
 
 Follow the steps provided in the guide **[Running PostGraphile in Docker](/postgraphile/running-postgraphile-in-docker/)** and come back to this guide to create the GraphQL container.
 
-# Table of Contents
+### Table of Contents
 
 -   [Create PostGraphile Container](#create-postgraphile-container)
     -   [Update Environment Variables](#update-environment-variables)
@@ -22,7 +22,7 @@ Follow the steps provided in the guide **[Running PostGraphile in Docker](/postg
     -   [Run Containers](#run-containers)
     -   [Re-initialize The Database](#re-initialize-the-database)
 
-# Create PostGraphile Container
+### Create PostGraphile Container
 
 At this stage, the repository should look like this.
 
@@ -37,7 +37,7 @@ At this stage, the repository should look like this.
 └─ docker-compose.yml
 ```
 
-## Update Environment Variables
+#### Update Environment Variables
 
 Update the file `.env` to add the `PORT` and `DATABASE_URL` which will be used by PostGraphile to connect to the PostgreSQL database. Note the `DATABASE_URL` follows the syntax `postgres://<user>:<password>@db:5432/<db_name>`.
 
@@ -49,7 +49,7 @@ DATABASE_URL=postgres://postgres:change_me@db:5432/forum_example
 PORT=5433
 ```
 
-## Create Node.js Application
+#### Create Node.js Application
 
 Create a new folder `graphql` at the root of the repository. It will be used to store the files necessary to create the PostGraphile container. In the `graphql` folder, create a subfolder `src` and add a file `package.json` into it with the following content.
 
@@ -86,7 +86,7 @@ http.createServer(
 ).listen(process.env.PORT);
 ```
 
-## Create PostGraphile Dockerfile
+#### Create PostGraphile Dockerfile
 
 Create a new file `Dockerfile` in the `graphql` folder (not in the folder `src`) with the following content.
 
@@ -112,7 +112,7 @@ EXPOSE 8080
 CMD [ "node", "server.js" ]
 ```
 
-## Update Docker Compose File
+#### Update Docker Compose File
 
 Update the file `docker-compose.yml` under the `services` section to include the GraphQL service.
 
@@ -156,67 +156,51 @@ At this stage, the repository should look like this.
 └─ docker-compose.yml
 ```
 
-# Build Images And Run Containers
+### Build Images And Run Containers
 
-## Build Images
+#### Build Images
 
 You can build the Docker images by executing the following command from the root of the repository.
 
 ```
-# Build all images in docker compose
+# Build images for all services in docker-compose.yml
 $ docker-compose build
 
-# Build database image only
+# You can also build images one by one
+# For instance you can build the database image like this
 $ docker-compose build db
 
-# Build graphql image only
+# And build the graphql image like this
 $ docker-compose build graphql
 ```
 
-## Run Containers
+#### Run Containers
 
 You can run the Docker containers by executing the following command from the root of the repository. Note when running the database container for the first time, Docker will automatically create a Docker Volume to persist the data from the database. The Docker Volume is automatically named as `<your_repository_name>_db`.
 
 ```
-# Run all containers
+# Run containers for all services in docker-compose.yml
 $ docker-compose up
 
-# Run all containers as daemon (in background)
+# Run containers as daemon (in background)
 $ docker-compose up -d
 
-# Run database container as daemon
+# Run only the database container as daemon
 $ docker-compose up -d db
 
-# Run graphql container as daemon
+# Run only the GraphQL container as daemon
 $ docker-compose up -d graphql
 ```
 
 Each container can be accessed at the following addresses. Note if you run Docker Toolbox on Windows Home, you can get your Docker machine IP address with the command `$ docker-machine ip default`.
 
-<table>
-    <tr>
-        <th>Container</th>
-        <th>Docker on Linux / Windows Pro</th>
-        <th>Docker on Windows Home</th>
-    </tr>
-    <tr>
-        <td>GraphQL API Documentation</td>
-        <td>https://localhost:5433/graphiql</td>
-        <td>https://your_docker_machine_ip:5433/graphiql</td>
-    </tr>
-    <tr>
-        <td>GraphQL API</td>
-        <td>https://localhost:5433/graphql</td>
-        <td>https://your_docker_machine_ip:5433/graphql</td>
-    </tr>
-    <tr>
-        <td>PostgreSQL Database</td>
-        <td>host: localhost, port: 5432</td>
-        <td>host: your_docker_machine_ip, port: 5432</td>
-    </tr>
-</table>
+| Container | Docker on Linux / Windows Pro | Docker on Windows Home |
+|-----------|-------------------------------|------------------------|
+| GraphQL API Documentation | https://localhost:5433/graphiql | https://your_docker_machine_ip:5433/graphiql |
+| GraphQL API | https://localhost:5433/graphql | https://your_docker_machine_ip:5433/graphql |
+| PostgreSQL Database | host: `localhost`, port: `5432` | host: `your_docker_machine_ip`, port: `5432` |
 
-## Re-initialize The Database
+#### Re-initialize The Database
 
 In case you do changes to the database schema by modifying the files in `/db/init`, you will need to re-initialize the database to see these changes. This means you need to delete the Docker Volume, the database Docker Image and rebuild it.
 

--- a/src/pages/postgraphile/running-postgraphile-as-a-library-in-docker.md
+++ b/src/pages/postgraphile/running-postgraphile-as-a-library-in-docker.md
@@ -223,8 +223,8 @@ the command `$ docker-machine ip default`.
 
 | Container | Docker on Linux / Windows Pro | Docker on Windows Home |
 |-----------|-------------------------------|------------------------|
-| GraphQL API Documentation | https://localhost:5433/graphiql | https://your_docker_machine_ip:5433/graphiql |
-| GraphQL API | https://localhost:5433/graphql | https://your_docker_machine_ip:5433/graphql |
+| GraphQL API Documentation | `https://localhost:5433/graphiql` | `https://your_docker_machine_ip:5433/graphiql` |
+| GraphQL API | `https://localhost:5433/graphql` | `https://your_docker_machine_ip:5433/graphql` |
 | PostgreSQL Database | host: `localhost`, port: `5432` | host: `your_docker_machine_ip`, port: `5432` |
 
 #### Re-initialize The Database

--- a/src/pages/postgraphile/running-postgraphile-as-a-library-in-docker.md
+++ b/src/pages/postgraphile/running-postgraphile-as-a-library-in-docker.md
@@ -18,18 +18,6 @@ Follow the steps provided in the guide
 **[Running PostGraphile in Docker](/postgraphile/running-postgraphile-in-docker/)**
 and come back to this guide to create the GraphQL container.
 
-### Table of Contents
-
-- [Create PostGraphile Container](#create-postgraphile-container)
-  - [Update Environment Variables](#update-environment-variables)
-  - [Create Node.js Application](#create-nodejs-application)
-  - [Create PostGraphile Dockerfile](#create-postgraphile-dockerfile)
-  - [Update Docker Compose File](#update-docker-compose-file)
-- [Build Images And Run Containers](#build-images-and-run-containers)
-  - [Build Images](#build-images)
-  - [Run Containers](#run-containers)
-  - [Re-initialize The Database](#re-initialize-the-database)
-
 ### Create PostGraphile Container
 
 At this stage, the repository should look like this.

--- a/src/pages/postgraphile/running-postgraphile-in-docker.md
+++ b/src/pages/postgraphile/running-postgraphile-in-docker.md
@@ -10,7 +10,7 @@ The following guide describes how to run a network of Docker containers on a loc
 -   Windows Pro
 -   Windows Home
 
-# Table of Contents
+### Table of Contents
 
 -   [Requirements](#requirements)
     -   [Install Docker and Docker Compose on Linux](#install-docker-and-docker-compose-on-linux)
@@ -35,7 +35,7 @@ The following guide describes how to run a network of Docker containers on a loc
     -   [Queries](#queries)
     -   [Mutations](#mutations)
 
-# Requirements
+### Requirements
 
 This requires to have Docker and Docker Compose installed on your workstation. If you are new to Docker and need to install it, you can refer to their [official documentation](https://docs.docker.com/) or follow the steps below. Note if you use Docker Desktop for Windows, it comes automatically with Docker Compose.
 
@@ -43,9 +43,9 @@ This requires to have Docker and Docker Compose installed on your workstation. I
 -   [Install Docker on Windows Pro](#install-docker-on-windows-pro)
 -   [Install Docker on Windows Home](#install-docker-on-windows-home)
 
-## Install Docker and Docker Compose on Linux
+#### Install Docker and Docker Compose on Linux
 
-### Docker
+##### Docker
 
 Add the Docker repository to your Linux repository. Execute the following commands in a terminal window.
 
@@ -82,7 +82,7 @@ $ docker image ls
 $ docker rmi -f hello-world
 ```
 
-### Docker Compose
+##### Docker Compose
 
 Docker Compose helps you to run a network of several containers at once thanks to configuration files instead of providing all arguments in the command line interface. It makes it easier to manage your containers as command lines can become very long and unreadable due to the high number of arguments.
 
@@ -92,21 +92,21 @@ Execute the following command in a terminal window.
 $ sudo apt install docker-compose
 ```
 
-## Install Docker on Windows Pro
+#### Install Docker on Windows Pro
 
-### Docker Desktop for Windows
+##### Docker Desktop for Windows
 
 Install Docker Community Edition for Windows from the following the URL: [Docker Desktop for Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows). Just follow the default installation settings. It comes automatically with Docker Compose.
 
-## Install Docker on Windows Home
+#### Install Docker on Windows Home
 
-### Docker Toolbox for Windows
+##### Docker Toolbox for Windows
 
 Install Docker Toolbox for Windows from the following the URL: [Docker Toolbox for Windows](https://docs.docker.com/toolbox/overview). Just follow the default installation settings. It comes automatically with Docker Compose.
 
-# Create PostgreSQL Container
+### Create PostgreSQL Container
 
-## Setup Environment Variables
+#### Setup Environment Variables
 
 Create a new file `.env` at the root of the repository with the content below. This file will be used by Docker to load configuration parameters into environment variables. In particular:
 
@@ -122,9 +122,9 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=change_me
 ```
 
-Note a better way to manager the database password would be to use [Docker Secrets](https://docs.docker.com/engine/reference/commandline/secret/)
+> Note: a better way to manager the database password would be to use [Docker Secrets](https://docs.docker.com/engine/reference/commandline/secret/)
 
-## Create Database Initialization Files
+#### Create Database Initialization Files
 
 Create a new folder `db` at the root of the repository. It will be used to store the files necessary to create the PostgreSQL container. In the `db` folder, create a new subfolder `init` which will contain the SQL files used to initialize the PostgreSQL database. Files located in the `init` folder will be executed in sequence order when PostgreSQL initialize the database.
 
@@ -176,7 +176,7 @@ INSERT INTO public.post (title, body, author_id) VALUES
 ('Third post example', 'Aenean blandit felis sodales', 3);
 ```
 
-## Create PostgreSQL Dockerfile
+#### Create PostgreSQL Dockerfile
 
 The Dockerfile is used by Docker as a blueprint to build Docker images. Docker containers are later on created based on these Docker images. More information is available on the official [Postgres Docker Images](https://hub.docker.com/_/postgres) but the standard Dockerfile for PostgreSQL is extremely simple. In the folder `db` (not in the folder `init`), create a new file named `Dockerfile` with the following content.
 
@@ -187,7 +187,7 @@ COPY ./init/ /docker-entrypoint-initdb.d/
 
 The first line `FROM postgres:alpine` indicates to build the Docker image based on the official PostgreSQL Docker image running in an Alpine Linux container. The second line `COPY ./init/ /docker-entrypoint-initdb.d/` will copy the database initialization files (SQL) into the folder `docker-entrypoint-initdb.d` located in the Docker container. This folder is read by PostgreSQL upon database initialization and all its content is executed.
 
-## Create Docker Compose File
+#### Create Docker Compose File
 
 Docker command lines can be verbose with a lot of parameters so we will use Docker Compose to orchestrate the execution of our containers. Create a new file `docker-compose.yml` at the root of the repository with the following content.
 
@@ -216,53 +216,21 @@ volumes:
     db:
 ```
 
-### Parameters description
+##### Parameters description
 
-<table>
-    <tr>
-        <th>Parameter</th><th>Description</th>
-    </tr>
-    <tr>
-        <td><b>db</b></td>
-        <td>Names of the services run by Docker Compose.</td>
-    </tr>
-    <tr>
-        <td><b>container_name</b></td>
-        <td>Guess what? It's the container name!</td>
-    </tr>
-    <tr>
-        <td><b>image</b></td>
-        <td>Name of the image to use to run the container.</td>
-    </tr>
-    <tr>
-        <td><b>build</b></td>
-        <td>When a build context is provided, Docker Compose will build a custom image using the Dockerfile located in the context folder.</td>
-    </tr>
-    <tr>
-        <td><b>context</b></td>
-        <td>Indicates the folder where to find the Dockerfile to build the image.</td>
-    </tr>
-    <tr>
-        <td><b>volumes</td>
-        <td>Mapping between the Docker volume and the PostgreSQL folder in your container, in format <b>docker_volume:container_folder</b>.<br><br>All the files generated in the <b>container_folder</b> will be copied in the <b>docker_volume</b> so that you can preserve and retrieve your data when stopping/restarting the container.<br><br>The Docker volume is automatically created when running the db container for the first time.</td>
-    </tr>
-    <tr>
-        <td><b>env_file</td>
-        <td>Path to the configuration file containing environment variables for the container. See <b>Create Configuration File</b> above.</td>
-    </tr>
-    <tr>
-        <td><b>networks</td>
-        <td>Networks are used to group and connect containers as part of a same network.</td>
-    </tr>
-    <tr>
-        <td><b>ports</td>
-        <td>Port, mapping between the port of your host machine and the port of your container, in format <b>host_port:container_port</b>.</td>
-    </tr>
-    <tr>
-        <td><b>command</td>
-        <td>Command to be executed after the container starts. Each argument must be provided in a separate list item.</td>
-    </tr>
-</table>
+| Parameter | Description |
+|-----------|-------------|
+| **db** | Names of the services run by Docker Compose. |
+| **container_name** | Guess what? It's the container name! |
+| **image** | Name of the image to use to run the container. |
+| **build** | When a build context is provided, Docker Compose will build a custom image using the Dockerfile located in the context folder. |
+| **context** | Indicates the folder where to find the Dockerfile to build the image. |
+| **volumes** | Mapping between the Docker volume and the PostgreSQL folder in your container, in format `docker_volume:container_folder`. All the files generated in the `container_folder` will be copied in the `docker_volume` so that you can preserve and retrieve your data when stopping/restarting the container. The Docker volume is automatically created when running the db container for the first time. |
+| **env_file** | Path to the configuration file containing environment variables for the container. See **Setup Environment Variables** above. |
+| **networks** | Networks are used to group and connect containers as part of a same network. |
+| **ports** | Port, mapping between the port of your host machine and the port of your container, in format `host_port:container_port` |
+| **command** | Command to be executed after the container starts. Each argument must be provided in a separate list item. |
+
 At this stage, the repository should look like this.
 
 ```
@@ -276,9 +244,9 @@ At this stage, the repository should look like this.
 └─ docker-compose.yml
 ```
 
-# Create PostGraphile Container
+### Create PostGraphile Container
 
-## Update Environment Variables
+#### Update Environment Variables
 
 Update the file `.env` to add the `DATABASE_URL` which will be used by PostGraphile to connect to the PostgreSQL database. Note the `DATABASE_URL` follows the syntax `postgres://<user>:<password>@db:5432/<db_name>`.
 
@@ -289,7 +257,7 @@ Update the file `.env` to add the `DATABASE_URL` which will be used by PostGraph
 DATABASE_URL=postgres://postgres:change_me@db:5432/forum_example
 ```
 
-## Create PostGraphile Dockerfile
+#### Create PostGraphile Dockerfile
 
 Create a new folder `graphql` at the root of the repository. It will be used to store the files necessary to create the PostGraphile container. Create a new file `Dockerfile` in the `graphql` folder with the following content. You will notice we include the excellent plugin Connection Filter.
 
@@ -305,7 +273,7 @@ EXPOSE 5000
 ENTRYPOINT ["postgraphile", "-n", "0.0.0.0"]
 ```
 
-## Update Docker Compose File
+#### Update Docker Compose File
 
 Update the file `docker-compose.yml` under the `services` section to include the GraphQL service.
 
@@ -347,67 +315,51 @@ At this stage, the repository should look like this.
 └─ docker-compose.yml
 ```
 
-# Build Images And Run Containers
+### Build Images And Run Containers
 
-## Build Images
+#### Build Images
 
 You can build the Docker images by executing the following command from the root of the repository.
 
 ```
-# Build all images in docker compose
+# Build images for all services in docker-compose.yml
 $ docker-compose build
 
-# Build database image only
+# You can also build images one by one
+# For instance you can build the database image like this
 $ docker-compose build db
 
-# Build graphql image only
+# And build the graphql image like this
 $ docker-compose build graphql
 ```
 
-## Run Containers
+#### Run Containers
 
 You can run the Docker containers by executing the following command from the root of the repository. Note when running the database container for the first time, Docker will automatically create a Docker Volume to persist the data from the database. The Docker Volume is automatically named as `<your_repository_name>_db`.
 
 ```
-# Run all containers
+# Run containers for all services in docker-compose.yml
 $ docker-compose up
 
-# Run all containers as daemon (in background)
+# Run containers as daemon (in background)
 $ docker-compose up -d
 
-# Run database container as daemon
+# Run only the database container as daemon
 $ docker-compose up -d db
 
-# Run graphql container as daemon
+# Run only the GraphQL container as daemon
 $ docker-compose up -d graphql
 ```
 
 Each container can be accessed at the following addresses. Note if you run Docker Toolbox on Windows Home, you can get your Docker machine IP address with the command `$ docker-machine ip default`.
 
-<table>
-    <tr>
-        <th>Container</th>
-        <th>Docker on Linux / Windows Pro</th>
-        <th>Docker on Windows Home</th>
-    </tr>
-    <tr>
-        <td>GraphQL API Documentation</td>
-        <td>https://localhost:5433/graphiql</td>
-        <td>https://your_docker_machine_ip:5433/graphiql</td>
-    </tr>
-    <tr>
-        <td>GraphQL API</td>
-        <td>https://localhost:5433/graphql</td>
-        <td>https://your_docker_machine_ip:5433/graphql</td>
-    </tr>
-    <tr>
-        <td>PostgreSQL Database</td>
-        <td>host: localhost, port: 5432</td>
-        <td>host: your_docker_machine_ip, port: 5432</td>
-    </tr>
-</table>
+| Container | Docker on Linux / Windows Pro | Docker on Windows Home |
+|-----------|-------------------------------|------------------------|
+| GraphQL API Documentation | https://localhost:5433/graphiql | https://your_docker_machine_ip:5433/graphiql |
+| GraphQL API | https://localhost:5433/graphql | https://your_docker_machine_ip:5433/graphql |
+| PostgreSQL Database | host: `localhost`, port: `5432` | host: `your_docker_machine_ip`, port: `5432` |
 
-## Re-initialize The Database
+#### Re-initialize The Database
 
 In case you do changes to the database schema by modifying the files in `/db/init`, you will need to re-initialize the database to see these changes. This means you need to delete the Docker Volume, the database Docker Image and rebuild it.
 
@@ -428,9 +380,9 @@ $ docker rmi db
 $ docker-compose up
 ```
 
-# Add Custom Plugin
+### Add Custom Plugin
 
-## makeWrapResolversPlugin
+#### makeWrapResolversPlugin
 
 This section is optional but describes how to wrap a resolver generated by PostGraphile in order to customize it. In the folder `graphql`, create a new subfolder named `custom-plugin`. In this folder create a new file `package.json` with the following content (you can update it to your convenience).
 
@@ -551,7 +503,7 @@ Finally rebuild and rerun the GraphQL container.
 # Shut down containers
 $ docker-compose down
 
-# Rebuilder GraphQL container
+# Rebuild the GraphQL container
 $ docker-compose build graphql
 
 # Rerun containers
@@ -560,9 +512,9 @@ $ docker-compose up
 
 If you execute a `createUser` mutation like in the example provided below, you will notice the log messages from the custom plugin printing in your terminal.
 
-# Queries And Mutations Examples
+### Queries And Mutations Examples
 
-## Queries
+#### Queries
 
 Example of query to get all posts and their author.
 
@@ -581,7 +533,7 @@ query {
 }
 ```
 
-## Mutations
+#### Mutations
 
 Example of mutation to create a new user.
 

--- a/src/pages/postgraphile/running-postgraphile-in-docker.md
+++ b/src/pages/postgraphile/running-postgraphile-in-docker.md
@@ -10,31 +10,6 @@ The following guide describes how to run a network of Docker containers on a loc
 - Windows Pro
 - Windows Home
 
-### Table of Contents
-
-- [Requirements](#requirements)
-  - [Install Docker and Docker Compose on Linux](#install-docker-and-docker-compose-on-linux)
-  - [Install Docker on Windows Pro](#install-docker-on-windows-pro)
-  - [Install Docker on Windows Home](#install-docker-on-windows-home)
-- [Create PostgreSQL Container](#create-postgresql-container)
-  - [Setup Environment Variables](#setup-environment-variables)
-  - [Create Database Initialization Files](#create-database-initialization-files)
-  - [Create PostgreSQL Dockerfile](#create-postgresql-dockerfile)
-  - [Create Docker Compose File](#create-docker-compose-file)
-- [Create PostGraphile Container](#create-postgraphile-container)
-  - [Update Environment Variables](#update-environment-variables)
-  - [Create PostGraphile Dockerfile](#create-postgraphile-dockerfile)
-  - [Update Docker Compose File](#update-docker-compose-file)
-- [Build Images And Run Containers](#build-images-and-run-containers)
-  - [Build Images](#build-images)
-  - [Run Containers](#run-containers)
-  - [Re-initialize The Database](#re-initialize-the-database)
-- [Add Custom Plugin](#add-custom-plugin)
-  - [makeWrapResolversPlugin](#makewrapresolversplugin)
-- [Queries And Mutations Examples](#queries-and-mutations-examples)
-  - [Queries](#queries)
-  - [Mutations](#mutations)
-
 ### Requirements
 
 This requires to have Docker and Docker Compose installed on your workstation. If you are new to Docker and need to install it, you can refer to their [official documentation](https://docs.docker.com/) or follow the steps below.

--- a/src/pages/postgraphile/running-postgraphile-in-docker.md
+++ b/src/pages/postgraphile/running-postgraphile-in-docker.md
@@ -37,11 +37,13 @@ The following guide describes how to run a network of Docker containers on a loc
 
 ### Requirements
 
-This requires to have Docker and Docker Compose installed on your workstation. If you are new to Docker and need to install it, you can refer to their [official documentation](https://docs.docker.com/) or follow the steps below. Note if you use Docker Desktop for Windows, it comes automatically with Docker Compose.
+This requires to have Docker and Docker Compose installed on your workstation. If you are new to Docker and need to install it, you can refer to their [official documentation](https://docs.docker.com/) or follow the steps below. 
 
 -   [Install Docker and Docker Compose on Linux](#install-docker-and-docker-compose-on-linux)
 -   [Install Docker on Windows Pro](#install-docker-on-windows-pro)
 -   [Install Docker on Windows Home](#install-docker-on-windows-home)
+
+> Note: If you use Docker Desktop for Windows, it comes automatically with Docker Compose.
 
 #### Install Docker and Docker Compose on Linux
 
@@ -248,7 +250,7 @@ At this stage, the repository should look like this.
 
 #### Update Environment Variables
 
-Update the file `.env` to add the `DATABASE_URL` which will be used by PostGraphile to connect to the PostgreSQL database. Note the `DATABASE_URL` follows the syntax `postgres://<user>:<password>@db:5432/<db_name>`.
+Update the file `.env` to add the `DATABASE_URL` which will be used by PostGraphile to connect to the PostgreSQL database.
 
 ```
 [...]
@@ -256,6 +258,8 @@ Update the file `.env` to add the `DATABASE_URL` which will be used by PostGraph
 # Parameters used by graphql container
 DATABASE_URL=postgres://postgres:change_me@db:5432/forum_example
 ```
+
+> Note: The `DATABASE_URL` follows the syntax `postgres://<user>:<password>@db:5432/<db_name>`.
 
 #### Create PostGraphile Dockerfile
 
@@ -335,7 +339,9 @@ $ docker-compose build graphql
 
 #### Run Containers
 
-You can run the Docker containers by executing the following command from the root of the repository. Note when running the database container for the first time, Docker will automatically create a Docker Volume to persist the data from the database. The Docker Volume is automatically named as `<your_repository_name>_db`.
+You can run the Docker containers by executing the following command from the root of the repository.
+
+> Note: when running the database container for the first time, Docker will automatically create a Docker Volume to persist the data from the database. The Docker Volume is automatically named as `<your_repository_name>_db`.
 
 ```
 # Run containers for all services in docker-compose.yml
@@ -351,13 +357,15 @@ $ docker-compose up -d db
 $ docker-compose up -d graphql
 ```
 
-Each container can be accessed at the following addresses. Note if you run Docker Toolbox on Windows Home, you can get your Docker machine IP address with the command `$ docker-machine ip default`.
+Each container can be accessed at the following addresses.
 
 | Container | Docker on Linux / Windows Pro | Docker on Windows Home |
 |-----------|-------------------------------|------------------------|
 | GraphQL API Documentation | https://localhost:5433/graphiql | https://your_docker_machine_ip:5433/graphiql |
 | GraphQL API | https://localhost:5433/graphql | https://your_docker_machine_ip:5433/graphql |
 | PostgreSQL Database | host: `localhost`, port: `5432` | host: `your_docker_machine_ip`, port: `5432` |
+
+> Note: if you run Docker Toolbox on Windows Home, you can get your Docker machine IP address with the command `$ docker-machine ip default`.
 
 #### Re-initialize The Database
 

--- a/src/pages/postgraphile/running-postgraphile-in-docker.md
+++ b/src/pages/postgraphile/running-postgraphile-in-docker.md
@@ -359,8 +359,8 @@ Each container can be accessed at the following addresses.
 
 | Container | Docker on Linux / Windows Pro | Docker on Windows Home |
 |-----------|-------------------------------|------------------------|
-| GraphQL API Documentation | https://localhost:5433/graphiql | https://your_docker_machine_ip:5433/graphiql |
-| GraphQL API | https://localhost:5433/graphql | https://your_docker_machine_ip:5433/graphql |
+| GraphQL API Documentation | `https://localhost:5433/graphiql` | `https://your_docker_machine_ip:5433/graphiql` |
+| GraphQL API | `https://localhost:5433/graphql` | `https://your_docker_machine_ip:5433/graphql` |
 | PostgreSQL Database | host: `localhost`, port: `5432` | host: `your_docker_machine_ip`, port: `5432` |
 
 > Note: if you run Docker Toolbox on Windows Home, you can get your Docker machine IP address with the command `$ docker-machine ip default`.

--- a/src/pages/postgraphile/running-postgraphile-in-docker.md
+++ b/src/pages/postgraphile/running-postgraphile-in-docker.md
@@ -156,7 +156,7 @@ INSERT INTO public.post (title, body, author_id) VALUES
 The Dockerfile is used by Docker as a blueprint to build Docker images. Docker containers are later on created based on these Docker images. More information is available on the official [Postgres Docker Images](https://hub.docker.com/_/postgres) but the standard Dockerfile for PostgreSQL is extremely simple. In the folder `db` (not in the folder `init`), create a new file named `Dockerfile` with the following content.
 
 ```dockerfile
-FROM postgres:alpine
+FROM postgres:11.0-alpine
 COPY ./init/ /docker-entrypoint-initdb.d/
 ```
 

--- a/src/pages/postgraphile/usage-library.md
+++ b/src/pages/postgraphile/usage-library.md
@@ -314,8 +314,7 @@ which are optional. The below options are valid for
   - `queryCacheMaxSize`: Max query cache size in bytes (extremely approximate,
     not accurate at all). Default `50000000` (~50MB). Set to 0 to disable.
   - `pgStrictFunctions`: When true, arguments which do not have a default value
-    in PostgreSQL functions marked as `STRICT` are set mandatory by
-    PostGraphile. See [Custom Mutations](/postgraphile/custom-mutations/).
+    in PostgreSQL functions marked as `STRICT` are set mandatory. See [Custom Mutations](/postgraphile/custom-mutations/).
 
 <!-- LIBRARY_DOCBLOCK_END -->
 <!-- prettier-ignore-end -->

--- a/src/pages/postgraphile/usage-library.md
+++ b/src/pages/postgraphile/usage-library.md
@@ -313,6 +313,9 @@ which are optional. The below options are valid for
     collections only (no Relay connections), "both" - both.
   - `queryCacheMaxSize`: Max query cache size in bytes (extremely approximate,
     not accurate at all). Default `50000000` (~50MB). Set to 0 to disable.
+  - `pgStrictFunctions`: When true, arguments which do not have a default value
+    in PostgreSQL functions marked as `STRICT` are set mandatory by
+    PostGraphile. See [Custom Mutations](/postgraphile/custom-mutations/).
 
 <!-- LIBRARY_DOCBLOCK_END -->
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
- Implement Benjie's feedback to remove table of content since it's automatically generated
- Add information how to use `pgStrictFunctions`
- Enforce PostgreSQL v11 for database Docker image to avoid issue when initialization db with data
