### PR TITLE
Add pin version of postgres and node image

### DIFF
--- a/src/pages/postgraphile/running-postgraphile-in-docker.md
+++ b/src/pages/postgraphile/running-postgraphile-in-docker.md
@@ -220,7 +220,7 @@ Dockerfile for PostgreSQL is extremely simple. In the folder `db` (not in the
 folder `init`), create a new file named `Dockerfile` with the following content.
 
 ```dockerfile
-FROM postgres:alpine
+FROM postgres:11.0-alpine
 COPY ./init/ /docker-entrypoint-initdb.d/
 ```
 
@@ -345,7 +345,7 @@ file `Dockerfile` in the `graphql` folder with the following content. You will
 notice we include the excellent plugin Connection Filter.
 
 ```dockerfile
-FROM node:alpine
+FROM node:12-alpine
 LABEL description="Instant high-performance GraphQL API for your PostgreSQL database https://github.com/graphile/postgraphile"
 
 # Install PostGraphile and PostGraphile connection filter plugin


### PR DESCRIPTION
Pinning of versioning for postgres and node since some of the images seem to have braking changes.
Versions have been pinned according to the starter directory.

```
starter/production.Dockerfile
10:FROM node:12-alpine as builder
32:FROM node:12-alpine as clean
67:FROM node:12-alpine
```

```
$ ag "image: postgres"
starter/docker-compose.yml
114:    image: postgres:11
```