### PR TITLE
example table name foos(id, ...) is misleading

### DIFF
--- a/src/pages/postgraphile/subscriptions.md
+++ b/src/pages/postgraphile/subscriptions.md
@@ -429,15 +429,19 @@ functions leave some optional spaces in, so when they are base64 encoded the
 strings do not match.)
 
 Assuming that you have a table of the form
-`foos(id serial primary key, title text, ...)` you can add the `__node__` field
+`app_public.foo(id serial primary key, title text, ...)` you can add the `__node__` field
 as follows and the record with id=32 will be made available as the `relatedNode`
 in the GraphQL subscription payload:
 
 ```sql
+insert into app_public.foo (title) values ('Howdy!') returning *;
 select pg_notify(
   'postgraphile:hello',
   json_build_object(
-    '__node__', json_build_array('foos', 32)
+    '__node__', json_build_array(
+      'foos',
+      (select max(id) from app_public.foo)
+    )
   )::text
 );
 ```


### PR DESCRIPTION
foos(id serial primary key, title text, ...) should read app_public.foo(id serial primary key, title text, ...) as the 'foo' is the name of the table in the SQL schema and foos is the name generated from @graphile-contrib/pg-simplify-inflector. The changes will emphasise the difference and align this example with other pieces of code on this page.
Also updated 

select pg_notify(
  'postgraphile:hello',
  json_build_object(
    '__node__', json_build_array('foos', 32)
  )::text
);

to 

insert into app_public.foo (title) values ('Howdy!') returning *;
select pg_notify(
  'postgraphile:hello',
  json_build_object(
    '__node__', json_build_array(
      'foos',
      (select max(id) from app_public.foo)
    )
  )::text
);

to better distinguish difference between foos and app_public.foo

NB, why is the nodeId and relatedNodeId returned as base64 (WyJmb29zIiwzMl0=)? Probably to save a bit of bandwith/CPU? For readability of the response when debugging I'd prefer it was shown/returned decoded. Possibly switch like --expandnodeid would be useful for debugging. Alas, I'm nitpicking here.