### PR TITLE
rename columns -> attribute in tag file example

### DIFF
--- a/src/pages/postgraphile/smart-tags-file.md
+++ b/src/pages/postgraphile/smart-tags-file.md
@@ -65,7 +65,7 @@ extension must be `.json5`) and is formatted like this:
          * We've added a shortcut to class-types so you can tag/describe
          * columns at the same time of the class.
          */
-        attributes: {
+        attribute: {
           /*
            * Assuming `body` is one of the columns in the 'post' table.
            */

--- a/src/pages/postgraphile/smart-tags-file.md
+++ b/src/pages/postgraphile/smart-tags-file.md
@@ -65,7 +65,7 @@ extension must be `.json5`) and is formatted like this:
          * We've added a shortcut to class-types so you can tag/describe
          * columns at the same time of the class.
          */
-        columns: {
+        attributes: {
           /*
            * Assuming `body` is one of the columns in the 'post' table.
            */


### PR DESCRIPTION
According to the library, `columns` is a deprecated name