### PR TITLE
Fix channel-name-being-a-heading

### DIFF
--- a/src/pages/postgraphile/aggregates.md
+++ b/src/pages/postgraphile/aggregates.md
@@ -14,8 +14,8 @@ need aggregates good starting points are:
   match the criteria (ignoring pagination info)
 - The [@graphile/pg-aggregates](https://github.com/graphile/pg-aggregates)
   module which adds `sum` aggregates to the schema (more to come)
-- The [Discord chat](http://discord.gg/graphile) (feel free to @benjie in
-  #help-and-support)
+- The [Discord chat](http://discord.gg/graphile) (feel free to @benjie
+  in #help-and-support)
 
 ### Aggregates ignore pagination info
 

--- a/src/pages/postgraphile/aggregates.md
+++ b/src/pages/postgraphile/aggregates.md
@@ -14,8 +14,8 @@ need aggregates good starting points are:
   match the criteria (ignoring pagination info)
 - The [@graphile/pg-aggregates](https://github.com/graphile/pg-aggregates)
   module which adds `sum` aggregates to the schema (more to come)
-- The [Discord chat](http://discord.gg/graphile) (feel free to @benjie
-  in #help-and-support)
+- The [Discord chat](http://discord.gg/graphile) (feel free to @benjie in
+  \#help-and-support)
 
 ### Aggregates ignore pagination info
 


### PR DESCRIPTION
Word wrapping caused `#help-and-support` to be at the beginning of a line rendering it as a heading.