### PR TITLE
Don't send 'authorization' header if no JWT

### DIFF
--- a/src/pages/postgraphile/security.md
+++ b/src/pages/postgraphile/security.md
@@ -130,7 +130,7 @@ Authorization: Bearer JWT_TOKEN_HERE
 e.g.
 [with Apollo](https://www.apollographql.com/docs/react/networking/authentication/#header):
 
-```js{7,12}
+```js{7,13}
 const httpLink = createHttpLink({
   uri: "/graphql",
 });
@@ -139,12 +139,20 @@ const authLink = setContext((_, { headers }) => {
   // get the authentication token from wherever you store it
   const token = getJWTToken();
   // return the headers to the context so httpLink can read them
+  if (token) {
+    return {
+      headers: {
+        ...headers,
+        authorization: `Bearer ${token}`,
+      },
+    }
+  }
   return {
     headers: {
       ...headers,
-      authorization: token ? `Bearer ${token}` : "",
+      // if no jwt, we don't want to pass the auth header at all
     },
-  };
+  }
 });
 
 const client = new ApolloClient({

--- a/src/pages/postgraphile/security.md
+++ b/src/pages/postgraphile/security.md
@@ -139,18 +139,11 @@ const authLink = setContext((_, { headers }) => {
   // get the authentication token from wherever you store it
   const token = getJWTToken();
   // return the headers to the context so httpLink can read them
-  if (token) {
-    return {
-      headers: {
-        ...headers,
-        authorization: `Bearer ${token}`,
-      },
-    }
-  }
   return {
     headers: {
       ...headers,
-      // if no jwt, we don't want to pass the auth header at all
+      // Only pass the authorization header if we have a JWT
+      ...(token ? { authorization: `Bearer ${token}` } : null),
     },
   }
 });


### PR DESCRIPTION
## Description
At some point, the Postgraphile code that parses the authorization headers (jwt) coming from the client was updated. This change made it so that in the absence of a jwt being stored on the client, *no* authorization header should be sent (as opposed to an empty string). The docs previously did not reflect that change— now they do.
