### PR TITLE
docs: note PrimaryKeyMutationsOnlyPlugin exists, affects CRUD

### DIFF
--- a/src/pages/postgraphile/crud-mutations.md
+++ b/src/pages/postgraphile/crud-mutations.md
@@ -91,6 +91,7 @@ generated schema:
 - Views instead of tables
 - Missing primary keys (though 'create' mutations will still be added in this
   case)
+- If you only see mutations using primary key: You might be using the `PrimaryKeyMutationsOnlyPlugin`
 
 Don't forget to check any associated `.postgraphilerc` for these settings too!
 


### PR DESCRIPTION
Add hint on why mutations using other identifier than primary key may be not visible.