### PR TITLE
Update default-role.md to fix the documentation's example.

### DIFF
--- a/src/pages/postgraphile/default-role.md
+++ b/src/pages/postgraphile/default-role.md
@@ -43,7 +43,7 @@ in:
 
 ```sql
 create role editor;
-create role editor nologin;
+create user editor nologin;
 ```
 
 “Logging in” just means we can use the role when authenticating in the


### PR DESCRIPTION


## Description
The example provided in the documentation shows equivalency between `create role` and `create user` query in postgres.

## Performance impact

None

## Security impact

None

## Checklist

_Not applicable_

- [ x] My code matches the project's code style and `yarn lint:fix` passes.
- [ x] I've added tests for the new feature, and `yarn test` passes.
- [ x] I have detailed the new feature in the relevant documentation.
- [ x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ x] If this is a breaking change I've explained why.


