### PR TITLE
Fix permission issue of package.json

### DIFF
--- a/src/pages/postgraphile/running-postgraphile-as-a-library-in-docker.md
+++ b/src/pages/postgraphile/running-postgraphile-as-a-library-in-docker.md
@@ -102,11 +102,12 @@ FROM node:alpine
 LABEL description="Instant high-performance GraphQL API for your PostgreSQL database https://github.com/graphile/postgraphile"
 
 # Set Node.js app folder
-RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
+RUN mkdir -p /home/node/app/node_modules
 WORKDIR /home/node/app
 
 # Copy dependencies
 COPY ./src/package*.json .
+RUN chown -R node:node /home/node/app
 
 # Install dependencies
 USER node


### PR DESCRIPTION
## Description

RUN "chown -R node:node /home/node/app" only after package.json was copied to make sure user node has proper permission, which is missing before.
