### PR TITLE
Fix error in PostgreSQL enum example.

### DIFF
--- a/src/pages/postgraphile/enums.md
+++ b/src/pages/postgraphile/enums.md
@@ -9,7 +9,7 @@ be automatically renamed in order to make sure they conform to the GraphQL
 naming requirements and conventions.
 
 ```sql
-create type animal_type as (
+create type animal_type as enum (
   'CAT',
   'DOG',
   'FISH'


### PR DESCRIPTION
This PR fixes the current enum example, which caused a syntax error.

As per the [PostgreSQL documentation](https://www.postgresql.org/docs/13/sql-createtype.html), the keyword `ENUM` is required when creating an enum type.

`Thank you for contributing to Graphile's Documentation!`
=> Thank _you_ for this amazing package!