### PR TITLE
Fix broken link to Relay

### DIFF
--- a/src/pages/postgraphile/security.md
+++ b/src/pages/postgraphile/security.md
@@ -155,7 +155,7 @@ const client = new ApolloClient({
 ```
 
 or
-[with Relay](https://facebook.github.io/relay/docs/en/network-layer.html):
+[with Relay](https://relay.dev/docs/guides/network-layer/)
 
 ```js{3,8}
 function fetchQuery( operation, variables, cacheConfig, uploadables) {

--- a/src/pages/postgraphile/security.md
+++ b/src/pages/postgraphile/security.md
@@ -155,7 +155,7 @@ const client = new ApolloClient({
 ```
 
 or
-[with Relay Modern](https://facebook.github.io/relay/docs/en/network-layer.html):
+[with Relay](https://facebook.github.io/relay/docs/en/network-layer.html):
 
 ```js{3,8}
 function fetchQuery( operation, variables, cacheConfig, uploadables) {


### PR DESCRIPTION
Fixed the link to the Relay network layer page. Also renamed Relay Modern to just Relay to match now Relay now generally refers to its current version.