### PR TITLE
docs(usage-cli): add jwtSignOptions

### DIFF
--- a/src/pages/postgraphile/usage-cli.md
+++ b/src/pages/postgraphile/usage-cli.md
@@ -285,6 +285,7 @@ Here is the list of keys and their default values, or types, supported in the
   jwtAudiences: <string>
   jwtRole = ['role']
   jwtSecret: <string>
+  jwtSignOptions: {}
   jwtTokenIdentifier
   jwtVerifyAlgorithms: <string>
   jwtVerifyAudience: <string>


### PR DESCRIPTION
Can be used to set `{ algorithm: 'RS256' }` for example.

I'm not sure if there is `--jwt-sign-options` too and how its input would look like though.

<!-- Thank you for contributing to Graphile's Documentation! -->
