### PR TITLE
update: news site and footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ then clear the `.cache` and `public` folders:
 rm -Rf .cache public
 ```
 
-Requires Node version 14
+Requires Node version 12
 
 ```bash
-nvm use 14
+nvm use 12
 ```
 
 If you are running Windows and encounter an error installing `fsevents`, then

--- a/link-check.js
+++ b/link-check.js
@@ -156,7 +156,7 @@ pMap(
     if (trimmed === "") {
       // Anchor link (#section-name), continue
       return;
-    } else if (trimmed.match(/\.(css|png|svg|webmanifest)$/)) {
+    } else if (trimmed.match(/\.(css|png|svg|webmanifest|xml)$/)) {
       // Resources
       return;
     } else if (isLocalhost5000) {

--- a/src/components/SiteFooter.js
+++ b/src/components/SiteFooter.js
@@ -62,7 +62,7 @@ const SiteFooter = () => {
                 </a>
               </li>
               <li>
-                <a href="https://fosstodon.org/@graphile">
+                <a href="https://fosstodon.org/@graphile" rel="me">
                   <i className="fab fa-mastodon" /> Mastodon
                 </a>
               </li>

--- a/src/components/SiteFooter.js
+++ b/src/components/SiteFooter.js
@@ -61,10 +61,19 @@ const SiteFooter = () => {
                   <i className="fab fa-discord" /> Chat (discord)
                 </a>
               </li>
-
+              <li>
+                <a href="https://fosstodon.org/@graphile">
+                  <i className="fab fa-mastodon" /> Mastodon
+                </a>
+              </li>
               <li>
                 <a href="https://twitter.com/graphilehq">
                   <i className="fab fa-twitter" /> Twitter
+                </a>
+              </li>
+              <li>
+                <a href="https://www.youtube.com/channel/UCPPQNCaD8ukbb5gp1KrYMqA">
+                  <i className="fa fa-play" /> Youtube
                 </a>
               </li>
               <li>

--- a/src/components/SiteHeader.js
+++ b/src/components/SiteHeader.js
@@ -319,6 +319,13 @@ export default class SiteHeader extends React.Component {
                   path="/news"
                   render={() => (
                     <li className="navbar-item">
+                      <Link className={`nav-link`} to="/news/rss.xml">
+                        <span aria-hidden="true" className="fa fa-rss-square" />{" "}
+                        <span className="rss">RSS</span>
+                      </Link>
+                      <Link className={`nav-link`} to="/sponsor/">
+                        Sponsor
+                      </Link>
                       <Link
                         className={`nav-link ${
                           location.pathname.match(/^\/news\/?$/) ? "active" : ""
@@ -326,19 +333,6 @@ export default class SiteHeader extends React.Component {
                         to="/news/"
                       >
                         Latest Announcements
-                      </Link>
-                    </li>
-                  )}
-                />
-                <Route
-                  path="/news/"
-                  render={() => (
-                    <li className="navbar-item">
-                      <Link
-                        className={"nav-link"}
-                        to="/news/postgraphile-version-4/"
-                      >
-                        Archive
                       </Link>
                     </li>
                   )}

--- a/src/components/SiteHeader.js
+++ b/src/components/SiteHeader.js
@@ -323,9 +323,23 @@ export default class SiteHeader extends React.Component {
                         <span aria-hidden="true" className="fa fa-rss-square" />{" "}
                         <span className="rss">RSS</span>
                       </Link>
+                    </li>
+                  )}
+                />
+                <Route
+                  path="/news"
+                  render={() => (
+                    <li className="navbar-item">
                       <Link className={`nav-link`} to="/sponsor/">
                         Sponsor
                       </Link>
+                    </li>
+                  )}
+                />
+                <Route
+                  path="/news"
+                  render={() => (
+                    <li className="navbar-item">
                       <Link
                         className={`nav-link ${
                           location.pathname.match(/^\/news\/?$/) ? "active" : ""

--- a/src/data/nav.json
+++ b/src/data/nav.json
@@ -42,6 +42,11 @@
         "sectionId": "about"
       },
       {
+        "to": "/news/20220607-schema-metadata/",
+        "title": "Schema Metadata: A Growing Need",
+        "sectionId": "misc"
+      },
+      {
         "to": "/news/20220607-spec-news/",
         "title": "Spec News Pod Launch",
         "sectionId": "misc"

--- a/src/data/nav.json
+++ b/src/data/nav.json
@@ -17,6 +17,11 @@
     ],
     "pages": [
       {
+        "to": "/news/20221208-graphql-galaxy/",
+        "title": "Step Aside Resolvers!",
+        "sectionId": "misc"
+      },
+      {
         "to": "/news/20221020-development-support/",
         "title": "Development Support Now Available",
         "sectionId": "about"

--- a/src/news/2021-12-07-graphql-galaxy-2021.md
+++ b/src/news/2021-12-07-graphql-galaxy-2021.md
@@ -10,8 +10,8 @@ thumbnailAlt:
   logo"
 
 summary:
-  "Benjie and Jem are pleased to announce the release of new podcast Spec News!
-  A monthly round up of GraphQL Spec news in under ten minutes."
+  "Benjie appeared on a virtual panel at GraphQL Galaxy 2021, discussing the
+  roles and aims of the GraphQL Working Group."
 ---
 
 _2021-12-07_

--- a/src/news/2022-06-07-schema-metadata.md
+++ b/src/news/2022-06-07-schema-metadata.md
@@ -1,0 +1,46 @@
+---
+layout: post
+title: "Schema Metadata: A Growing Need"
+date: 2022-06-07T02:00:00Z
+path: /news/20220607-schema-metadata/
+tags: conference, graphql
+thumbnail: /images/news/youtube.svg
+thumbnailAlt:
+  "A cartoon developer leans against an oversized laptop showing the YouTube
+  logo"
+
+summary:
+  "Benjie gave on a virtual talk at the GraphQL Conf 2022 which highlighted the
+  need for GraphQL schema metadata and explored some of the proposed solutions
+  to this problem."
+---
+
+_2022-06-07_
+
+This week, Benjie gave a virtual talk at
+[GraphQL Conf](https://graphql.org/foundation/graphql-conf/) - the first
+official GraphQL Conference hosted by the GraphQL Foundation.
+
+Benjie was one of eight GraphQL experts giving a talk on the cutting edge of
+GraphQL advancements; his talk focused on the need for a defined approach to
+GraphQL schema metadata. From complex challenges such as federating schemas to
+simply indicating pagination limits, the needs for this metadata are growing.
+This talk surfaced some of the use cases for schema metadata, looked over some
+of the workarounds that are in use, and briefly explored some proposed
+solutions.
+
+<div class="tc">
+<iframe 
+width="560"
+height="315"
+src="https://www.youtube-nocookie.com/embed/FC4AFSjh_4k"
+title="YouTube video player"
+frameborder="1" 
+style="border: 6px solid #1b1b3d; border-radius: 10px"
+allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+allowfullscreen>
+</iframe>
+</div>
+
+You can also see the talk
+[on YouTube](https://www.youtube.com/watch?v=FC4AFSjh_4k&list=PLP1igyLx8foGJrtkgYL9nunvC5qMXTVaa&index=2).

--- a/src/news/2022-12-08-graphql-galaxy-2021.md
+++ b/src/news/2022-12-08-graphql-galaxy-2021.md
@@ -43,5 +43,5 @@ heavy iteration. All sponsors can request access to the binaries and
 documentation; Featured Tier sponsors can gain access to the repository, issues
 and support. [Find out more about sponsorship on our website](/sponsor/).
 
-_You can also see the talk
-[on YouTube](https://www.youtube.com/watch?v=H26uBe_lLag)._
+You can also see the talk
+[on YouTube](https://www.youtube.com/watch?v=H26uBe_lLag).

--- a/src/news/2022-12-08-graphql-galaxy-2021.md
+++ b/src/news/2022-12-08-graphql-galaxy-2021.md
@@ -1,0 +1,47 @@
+---
+layout: post
+title: "Step Aside Resolvers: a New Approach to GraphQL Execution"
+date: 2022-12-08T01:00:00Z
+path: /news/20221208-graphql-galaxy/
+tags: conference, graphql, grafast
+thumbnail: /images/grafast-hero.png
+thumbnailAlt:
+  "A cartoon man reveals a superhero costume from under his shirt, in the style
+  of Superman. Instead of the S, it's a green Graphile heart logo."
+
+summary:
+  "Benjie introduces a new, holistic approach to GraphQL Execution at GraphQL
+  Galaxy 2022. This talk is the first public look at the ludicrously speedy,
+  general purpose, holistic advanced planning and execution engine codenamed
+  Grafast."
+---
+
+_2022-12-07_
+
+This week at [GraphQL Galaxy](https://graphqlgalaxy.com/), Benjie introduced his
+vision for a new general-purpose GraphQL execution strategy whose holistic
+approach could lead to significant efficiency and scalability gains for all
+GraphQL APIs. This talk is the first public look at the ludicrously speedy,
+general purpose and holistic advanced planning and execution engine codenamed
+Grafast.
+
+<div class="tc">
+<iframe 
+width="560"
+height="315"
+src="https://www.youtube-nocookie.com/embed/H26uBe_lLag"
+title="YouTube video player"
+frameborder="1" 
+style="border: 6px solid #1b1b3d; border-radius: 10px"
+allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+allowfullscreen>
+</iframe>
+</div>
+
+Grafast is already available to Graphile sponsors whilst it is still undergoing
+heavy iteration. All sponsors can request access to the binaries and
+documentation; Featured Tier sponsors can gain access to the repository, issues
+and support. [Find out more about sponsorship on our website](/sponsor/).
+
+_You can also see the talk
+[on YouTube](https://www.youtube.com/watch?v=H26uBe_lLag)._


### PR DESCRIPTION
<!-- Thank you for contributing to Graphile's Documentation! -->

A news update for the Grafast talk at GraphQL Galaxy 2022
A news update for the Schema Metadata talk at GraphQL Foundation Conf 2022

plus
- Fix description of GraphQL Galaxy 2021 article
- Changes to News site header:
- - RSS link
- - Sponsor link
- Changes to site-wide footer:
- - Mastodon
- - Youtube
- Readme states correct node version