### PR TITLE
Check if forward relation field is non nullable in example plugin

### DIFF
--- a/src/pages/postgraphile/why-nullable.md
+++ b/src/pages/postgraphile/why-nullable.md
@@ -192,7 +192,10 @@ GraphQLNonNull-wrapped version of their original type:
 ```js
 module.exports = function NonNullRelationsPlugin(builder) {
   builder.hook("GraphQLObjectType:fields:field", (field, build, context) => {
-    if (!context.scope.isPgForwardRelationField) {
+    if (
+      !context.scope.isPgForwardRelationField ||
+      !context.scope.pgFieldIntrospection?.keyAttributes?.at(0)?.isNotNull
+    ) {
       return field;
     }
     return {

--- a/src/pages/postgraphile/why-nullable.md
+++ b/src/pages/postgraphile/why-nullable.md
@@ -194,7 +194,7 @@ module.exports = function NonNullRelationsPlugin(builder) {
   builder.hook("GraphQLObjectType:fields:field", (field, build, context) => {
     if (
       !context.scope.isPgForwardRelationField ||
-      !context.scope.pgFieldIntrospection?.keyAttributes?.at(0)?.isNotNull
+      !context.scope.pgFieldIntrospection?.keyAttributes?.every(attr => attr.isNotNull)
     ) {
       return field;
     }


### PR DESCRIPTION
I think it could make sense to mark the graphql field as non-null only if the column is not nullable in the database.