### PR TITLE
update: Pro Plan update

### DIFF
--- a/src/components/Layout/index.scss
+++ b/src/components/Layout/index.scss
@@ -576,20 +576,35 @@ h6 code {
 }
 .pricing-table td,
 .pricing-table th {
-  width: 25%;
+  width: 20%;
 }
 .pricing-table thead th {
   @extend .f3;
   @extend .pb3;
-  border-bottom: 2px solid #a51b1b;
+  font-size: 1.2rem;
 }
+
+.pricing-table thead tr:first-child,
+.pricing-table thead tr:first-child th {
+  padding-bottom: 0.5rem;
+}
+
+.pricing-table thead tr:last-child,
+.pricing-table thead tr:last-child th {
+  font-style: italic;
+  color: #555;
+  font-size: 0.8rem;
+  padding-top: 0;
+  border-bottom: 2px solid #2d437d;
+}
+
 .pricing-table tbody th,
 .pricing-table tbody td {
   @extend .pv3;
   @extend .ph1;
 }
 .pricing-table tbody tr {
-  border-bottom: 1px solid #a51b1b;
+  border-bottom: 1px solid #2d437d;
 }
 .pricing-table tbody tr:last-child th,
 .pricing-table tbody tr:last-child td {
@@ -609,10 +624,10 @@ h6 code {
   @extend .f3;
 }
 .pricing-table .fa-check-circle {
-  color: green;
+  color: #4a68b4;
 }
 .pricing-table .fa-times-circle {
-  color: red;
+  color: rgb(255, 71, 81);
 }
 .pricing-table .fa-minus-circle {
   color: #ccc;
@@ -712,22 +727,30 @@ h6 code {
         position: relative;
         padding-left: 40%;
       }
+    }
+    tbody,
+    tfoot {
       td::before {
-        content: "Placeholder";
+        content: "";
         position: absolute;
         left: 0.5rem;
         top: 0;
         font-variant: small-caps;
         font-size: 1.2em;
       }
-      td:nth-of-type(1)::before {
-        content: "Core";
-      }
       td:nth-of-type(2)::before {
-        content: "Supporter";
+        content: "Pro";
       }
       td:nth-of-type(3)::before {
-        content: "Pro";
+        content: "Sponsor+";
+      }
+      td:nth-of-type(4)::before {
+        content: "Enterprise";
+      }
+    }
+    tbody {
+      td:nth-of-type(1)::before {
+        content: "Core";
       }
     }
   }
@@ -749,14 +772,14 @@ h6 code {
   font-weight: normal;
 }
 
-.plan-supporter {
+.plan-sponsor {
   @extend .plan-tag;
-  background-color: #4d4dff;
+  background-color: rgb(45, 128, 211);
 }
 
 .plan-pro {
   @extend .plan-tag;
-  background-color: #c511c5;
+  background-color: rgb(255, 71, 81);
 }
 .plan-enterprise {
   @extend .plan-tag;
@@ -768,6 +791,55 @@ h6 code {
   }
 }
 
+/* Tooltip container */
+.tooltipped {
+  position: relative;
+  display: inline-block;
+  text-decoration: underline dotted 2px #4a68b4;
+}
+
+/* Tooltip text */
+.tooltipped > .tooltip-text {
+  display: block;
+  visibility: hidden;
+  width: 220px;
+  background-color: #f4faff;
+  border: 2px solid #cbe3ff;
+  color: black;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 10;
+}
+
+.tooltipped:hover > .tooltip-text {
+  visibility: visible;
+  top: -5px;
+  right: 105%;
+}
+
+.tooltipped > .tooltip-text::after {
+  content: " ";
+  position: absolute;
+  top: 50%;
+  left: 100%; /* To the right of the tooltip */
+  margin-top: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent transparent transparent #cbe3ff;
+}
+
+.show-full {
+  display: contents;
+}
+
+.show-mobile {
+  display: none;
+}
+
 // ----------------------------------------
 // Misc media queries
 
@@ -777,6 +849,12 @@ h6 code {
     &:before {
       left: 50%;
     }
+  }
+  .show-full {
+    display: none;
+  }
+  .show-mobile {
+    display: contents;
   }
 }
 

--- a/src/components/Layout/index.scss
+++ b/src/components/Layout/index.scss
@@ -795,7 +795,7 @@ h6 code {
 .tooltipped {
   position: relative;
   display: inline-block;
-  text-decoration: underline dotted 2px #4a68b4;
+  text-decoration: underline dotted 2px #a1a1a1;
 }
 
 /* Tooltip text */
@@ -803,8 +803,8 @@ h6 code {
   display: block;
   visibility: hidden;
   width: 220px;
-  background-color: #f4faff;
-  border: 2px solid #cbe3ff;
+  background-color: white;
+  border: 2px solid #a1a1a1;
   color: black;
   text-align: center;
   padding: 5px 0;
@@ -818,18 +818,18 @@ h6 code {
 .tooltipped:hover > .tooltip-text {
   visibility: visible;
   top: -5px;
-  right: 105%;
+  left: 105%;
 }
 
 .tooltipped > .tooltip-text::after {
   content: " ";
   position: absolute;
   top: 50%;
-  left: 100%; /* To the right of the tooltip */
+  right: 100%; /* To the left of the tooltip */
   margin-top: -5px;
   border-width: 5px;
   border-style: solid;
-  border-color: transparent transparent transparent #cbe3ff;
+  border-color: transparent #555 transparent transparent;
 }
 
 .show-full {

--- a/src/components/Layout/index.scss
+++ b/src/components/Layout/index.scss
@@ -573,6 +573,7 @@ h6 code {
 .pricing-table {
   width: 100%;
   border-collapse: collapse;
+  margin-top: 2rem;
 }
 .pricing-table td,
 .pricing-table th {
@@ -773,6 +774,11 @@ h6 code {
 }
 
 .plan-sponsor {
+  @extend .plan-tag;
+  background-color: rgb(45, 128, 211);
+}
+
+.plan-supporter {
   @extend .plan-tag;
   background-color: rgb(45, 128, 211);
 }

--- a/src/pages/postgraphile/live-queries.md
+++ b/src/pages/postgraphile/live-queries.md
@@ -249,7 +249,7 @@ lot more that can be done to optimise our logical decoding support, so if you
 get to a point where logical decoding performance is an issue, please get in
 touch!
 
-Optimisation steps you can take currently:
+Optimization steps you can take currently:
 
 - Whitelist (or otherwise limit) the live queries that your system may perform
 - Only write small non-overlapping live queries - since the entire query must
@@ -261,12 +261,12 @@ Optimisation steps you can take currently:
 - Move the logical decoding system to a dedicated server
 - Add more `liveConditions` to queries to filter rows the user may not see so
   that they do not trigger live updates for that user (TODO: document this!)
-- Use read replicas [PRO]
+- Use read replicas [PRO]&nbsp;[SPON]
 
 We do not currently recommend live queries for very large deployments - if
 you're expecting tens of thousands of concurrent users it's going to be
 significantly more efficient to use regular
-[subscriptions](/postgraphile/subscriptions/)
+[subscriptions](/postgraphile/subscriptions/).
 
 ### Scaling
 

--- a/src/pages/postgraphile/plugins.md
+++ b/src/pages/postgraphile/plugins.md
@@ -33,8 +33,8 @@ There are also a couple of first-party plugins that may be purchased on the
 
 - ~~`@graphile/supporter`~~ - all features now OSS via `@graphile/pg-pubsub`
   plugin
-- `@graphile/pro` [PRO] - includes protections that can be mounted in front of
-  PostGraphile to protect it from malicious actors
+- `@graphile/pro` [PRO]&nbsp;[SPON] - includes protections that can be mounted
+  in front of PostGraphile to protect it from malicious actors
 
 To use these premium plugins you will need a `GRAPHILE_LICENSE` environmental
 variable to be present, as in these examples:

--- a/src/pages/postgraphile/pricing.md
+++ b/src/pages/postgraphile/pricing.md
@@ -56,7 +56,14 @@ any other benefit such as priority support or discounted consultancy rates.
 </tr>
 
 <tr>
-  <th>OSS projects, not-for-profits</th>
+  <th>
+  <span class='tooltipped'>
+    OSS projects, not-for-profits
+    <span class='tooltip-text'>Also, hobbyists, pre-revenue start-ups, and any other use
+    where the Pro features are either not needed or can be re-implemented by your team
+    </span>
+    </span>
+    </th>
   <th>Small businesses</th>
   <th>Small and medium businesses</th>
   <th>Enterprise</th>
@@ -66,15 +73,13 @@ any other benefit such as priority support or discounted consultancy rates.
 <tbody>
 
 <tr>
-  <th>Instant GraphQL API<br />(queries and mutations)</th>
-  <td><span class='fas fa-check-circle'></span></td>
-  <td><span class='fas fa-check-circle'></span></td>
-  <td><span class='fas fa-check-circle'></span></td>
-  <td><span class='fas fa-check-circle'></span></td>
-</tr>
-
-<tr>
-  <th>Automatic CRUD mutations</th>
+  <th>
+    <span class='tooltipped'>
+      Instant GraphQL API
+      <span class='tooltip-text'>Queries and mutations</span>
+    </span>
+    &nbsp;and automatic CRUD mutations
+  </th>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
@@ -90,7 +95,14 @@ any other benefit such as priority support or discounted consultancy rates.
 </tr>
 
 <tr>
-  <th>Authentication via JWT or custom <code>pgSettings</code></th>
+  <th>
+    <span class='tooltipped'>
+      Authentication
+      <span class='tooltip-text'>
+        via JWT or custom <code>pgSettings</code>
+      </span>
+    </span>
+  </th>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
@@ -98,7 +110,11 @@ any other benefit such as priority support or discounted consultancy rates.
 </tr>
 
 <tr>
-  <th>RLS and RBAC authorization</th>
+    <th>
+    <span class='tooltipped'>
+      Authorization<span class='tooltip-text'>RLS and RBAC</span>
+    </span>
+  </th>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
@@ -122,15 +138,7 @@ any other benefit such as priority support or discounted consultancy rates.
 </tr>
 
 <tr>
-  <th>Filtering</th>
-  <td><span class='fas fa-check-circle'></span></td>
-  <td><span class='fas fa-check-circle'></span></td>
-  <td><span class='fas fa-check-circle'></span></td>
-  <td><span class='fas fa-check-circle'></span></td>
-</tr>
-
-<tr>
-  <th>Ordering</th>
+  <th>Filtering &amp; Ordering</th>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
@@ -178,7 +186,14 @@ any other benefit such as priority support or discounted consultancy rates.
 </tr>
 
 <tr>
-  <th>Real-time GraphQL</a></th>
+  <th>
+    <span class='tooltipped'>
+      Real-time GraphQL
+      <span class='tooltip-text'>
+        GraphQL Subscriptions and Live Queries
+      </span>
+    </span>
+  </th>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
@@ -218,7 +233,7 @@ any other benefit such as priority support or discounted consultancy rates.
 </tr>
 
 <tr>
-  <th>Free access to pgRITA</th>
+  <th>Free access to <a href="https://pgrita.com">pgRITA</a></th>
   <td><span class='fas fa-times-circle'></span></td>
   <td><span class='fas fa-times-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
@@ -226,7 +241,7 @@ any other benefit such as priority support or discounted consultancy rates.
 </tr>
 
 <tr>
-  <th>Logo featured on website</th>
+  <th>Logo featured on <a href="https://graphile.org/sponsor">website</a></th>
   <td><span class='fas fa-times-circle'></span></td>
   <td><span class='fas fa-times-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
@@ -245,16 +260,42 @@ any other benefit such as priority support or discounted consultancy rates.
   <th>Sponsor's discount</th>
   <td><span class='fas fa-times-circle'></span></td>
   <td><span class='fas fa-times-circle'></span></td>
-  <td>Discounted video calls</td>
-  <td>Discounted consultancy packages</td>
+  <td>    
+    <span class='show-full'>
+      Discounted <a href="https://benjie.dev/book">video calls</a>
+    </span>
+    <span class='show-mobile'>
+      <span class="f3 fa fa-phone-square"></span>
+    </span></td>
+  <td>
+    <span class='show-full'>
+      Discounted consultancy packages
+    </span>
+    <span class='show-mobile'>
+      <span class='fas fa-check-circle'></span>
+    </span>
+  </td>
 </tr>
 
 <tr>
   <th>Support</th>
-  <td>via community Discord</td>
-  <td>via community Discord</td>
-  <td>Priority support via community Discord</td>
-  <td>Within your own company</td>
+  <td>
+    <span class='show-full'>via community Discord</span>
+    <span class='show-mobile'>Community support</span>
+  </td>
+  <td>
+    <span class='show-full'>via community Discord</span>
+    <span class='show-mobile'>Community support</span>
+  </td>
+  <td>
+    <span class='show-full'>Priority support via community Discord</span>
+    <span class='show-mobile'>Priority community support</span>
+  </td>
+  <td>Within your own company <br />
+    <span class="f3 fab fa-github"></span>
+    <span class="f3 fab fa-slack"></span>
+    <span class="f3 fa fa-phone-square"></span>
+  </td>
 </tr>
 
 <tr>
@@ -267,10 +308,29 @@ any other benefit such as priority support or discounted consultancy rates.
 
 <tr>
   <th>Pricing</th>
-  <td><strong><a href='/sponsor/'>Crowd-funded</a></strong><span class='note'>Please give back</span></td>
-  <td><strong><small><s>$100/mo</s> USD</small> $25<small>/mo</small></strong><span class='note'><small>EUR €25/mo, GBP £20/mo excluding VAT</small></span></td>
-  <td><small>From</small> <strong>$100<small>/mo USD</small></strong><span class='note'><small>GitHub Sponsors or annual invoicing</small></span></td>
-    <td><small>From</small> <strong>$1,500<small>/mo USD</small></strong><span class='note'><small>GitHub Sponsors or bespoke invoicing</small></span></td>
+  <td>
+    <strong><a href='/sponsor/'>Crowd-funded</a></strong><br />
+    <span class='show-full'>
+    <span class='note'><small>Please give back</small>
+    </span>
+    </span>
+  </td>
+  <td>
+    <strong><span class='show-full'><small><s>$100/mo</s></small></span> $25<small> /mo USD</small></strong>
+    <span class='show-full'>
+    <span class='note'><small>EUR €25/mo, GBP £20/mo <br />excluding VAT</small>
+    </span>
+    </span>
+  </td>
+  <td><small>From</small> <strong>$100<small>/mo USD</small></strong>
+  <span class='show-full'>
+  <span class='note'><small>GitHub Sponsors <br />or annual invoicing</small></span>
+  </span>
+  </td>
+  <td><small>From</small> <strong>$1,500<small>/mo USD</small></strong>
+  <span class='show-full'>
+  <span class='note'><small>GitHub Sponsors <br />or bespoke invoicing</small></span>
+  </span></td>
 </tr>
 
 </tbody>

--- a/src/pages/postgraphile/pricing.md
+++ b/src/pages/postgraphile/pricing.md
@@ -46,7 +46,7 @@ any other benefit such as priority support or discounted consultancy rates.
 <p class='show-mobile'>
   There are several tiers of sponsorship available; The "Production
   Sponsor" tier (<strong>Sponsor+</strong>) is suitable for many small and
-  medium businesses while the "Private Advisor Tier" (<strong>Enterprise</strong>) gives access to a complimentary <a href="https://www.graphile.org/support/">Development Support </a> contract and discounted consultancy packages, perfect for enterprises and those who need bespoke advice and support on their project.
+  medium businesses while the "Private Advisor Tier" (<strong>Enterprise</strong>) gives access to a complimentary <a href="/support/">Development Support </a> contract and discounted consultancy packages, perfect for enterprises and those who need bespoke advice and support on their project.
 </p>
 
 <p class='show-full'>
@@ -57,7 +57,7 @@ any other benefit such as priority support or discounted consultancy rates.
   the database tool <a href="https://pgrita.com">pgRITA </a> and discounted
   consultancy calls. The "Private Advisor Tier" gives access to a
   complimentary
-  <a href="https://www.graphile.org/support/">Development Support </a> contract
+  <a href="/support/">Development Support </a> contract
   and discounted consultancy packages, perfect for enterprises and those who
   need bespoke advice and support on their project.
 </p>

--- a/src/pages/postgraphile/pricing.md
+++ b/src/pages/postgraphile/pricing.md
@@ -348,7 +348,7 @@ any other benefit such as priority support or discounted consultancy rates.
 
 </table>
 
-##### <sup>‡</sup> These features integrate deeply with PostGraphile and have been optimized for its nuances by the maintainer. If you wish to build and maintain protections yourself rather than using the Pro plugin, refer to [Running in Production](/postgraphile/production/) for information on how you might go about doing this. Purchasing the Pro plugin helps fund ongoing development and maintenance on the open source PostGraphile project.
+##### <sup>‡</sup> These features integrate deeply with PostGraphile and have been optimized for its nuances by the maintainer. If you wish to build and maintain protections yourself rather than using the Pro plugin, refer to [Production Considerations](/postgraphile/production/) for information on how you might go about doing this. Purchasing the Pro plugin helps fund ongoing development and maintenance on the open source PostGraphile project.
 
 </div>
 </div>

--- a/src/pages/postgraphile/pricing.md
+++ b/src/pages/postgraphile/pricing.md
@@ -41,7 +41,26 @@ For businesses which are not capable of engaging in the sponsorship model, there
 is an option to purchase the license by itself. However, this does not come with
 any other benefit such as priority support or discounted consultancy rates.
 
-### Feature comparison
+#### Feature comparison
+
+<p class='show-mobile'>
+  There are several tiers of sponsorship available; The "Production
+  Sponsor" tier (<strong>Sponsor+</strong>) is suitable for many small and
+  medium businesses while the "Private Advisor Tier" (<strong>Enterprise</strong>) gives access to a complimentary <a href="https://www.graphile.org/support/">Development Support </a> contract and discounted consultancy packages, perfect for enterprises and those who need bespoke advice and support on their project.
+</p>
+
+<p class='show-full'>
+  Below, we have listed the differences between PostGraphile V4 Core, purchasing
+  the license by itself, and sponsoring Graphile. There are several tiers of
+  sponsorship available; The "Production Sponsor" tier is suitable
+  for many small and medium businesses with some perks such as free access to
+  the database tool <a href="https://pgrita.com">pgRITA </a> and discounted
+  consultancy calls. The "Private Advisor Tier" gives access to a
+  complimentary
+  <a href="https://www.graphile.org/support/">Development Support </a> contract
+  and discounted consultancy packages, perfect for enterprises and those who
+  need bespoke advice and support on their project.
+</p>
 
 <table class='pricing-table'>
   <thead>

--- a/src/pages/postgraphile/pricing.md
+++ b/src/pages/postgraphile/pricing.md
@@ -12,7 +12,7 @@ title: PostGraphile Pro!
 
 # Get PostGraphile Pro
 
-#### PostGraphile core is open source software under the MIT license. Pro is a commercial plugin which enhances PostGraphile with additional features and helps fund development and maintenance on PostGraphile Core.
+#### PostGraphile V4 Core is open source software under the MIT license. Pro is a commercial plugin which enhances PostGraphile V4 with additional features to help your team to save development costs before deploying to production.
 
 ##### See below the pricing table for more information.
 
@@ -29,6 +29,20 @@ title: PostGraphile Pro!
 
 <div class='row'>
 <div class='text-center col-xs-12'>
+
+### How to get Pro
+
+PostGraphile Pro is available as a perk for
+[Graphile sponsors](https://graphile.org/sponsor/). Businesses which use
+PostGraphile should explore sponsorship as the first option to obtain Pro, as
+sponsorship also helps to fund development and maintenance of the Graphile
+suite, as well as enabling us to advance the software they rely on.
+
+For businesses which are not capable of engaging in the sponsorship model, there
+is an option to purchase the license by itself. However, this does not come with
+any other benefit such as priority support or discounted consultancy rates.
+
+### Feature comparison
 
 <table class='pricing-table'>
   <thead>
@@ -216,18 +230,19 @@ Questions, comments or feedback? Email
 <div class='row'>
 <div class='text-center col-xs-12'>
 
-### PostGraphile core is OSS under the MIT license
+### PostGraphile V4 Core and PostGraphile V5 are OSS under the MIT license
 
-PostGraphile core is sufficient for many peoples needs; it's the only version
+PostGraphile V4 Core is sufficient for many peoples needs; it's the only version
 that existed for the first 2 years of the project and many people are running it
-with great success in production. No features in PostGraphile core have been
-removed or obscured, and it continues to be advanced and enhanced.
+with great success in production. No features in PostGraphile V4 Core have been
+removed or obscured, and it continues to be maintained. PostGraphile V5 is also
+open source under the MIT License and continues to be advanced and enhanced.
 
-Development and maintenance of PostGraphile core is ongoing, supported by
-contributions from the community, [professional services](/support/) contracts,
-[GitHub Sponsors](/sponsor/) and sales of commercial plugin licenses.
+Development and maintenance of PostGraphile V5 is ongoing, supported by
+contributions from the community, [professional services](/support/) contracts
+and [GitHub Sponsors](/sponsor/).
 
-### PostGraphile Pro is a commercial plugin
+### PostGraphile Pro is a commercial plugin for those who wish to scale with PostGraphile V4
 
 The Pro plugin enhances PostGraphile with additional features and is loaded
 through the standard [server plugin interface](/postgraphile/plugins/).
@@ -236,7 +251,7 @@ The Pro plugin contains features that are particularly useful to businesses
 wishing to scale their solution out using database read-replicas or protect the
 generated GraphQL API from expensive queries which may be issued by untrusted
 third parties. (Typically if the intended clients to your GraphQL API are
-first-party only then you would use a GraphQL query whitelist (e.g. persisted
+first-party only then you would use a GraphQL query allowlist (e.g. persisted
 queries) for this purpose; although the Pro features can still be helpful to
 dissuade your developers from building expensive queries!)
 
@@ -279,7 +294,8 @@ There's also a lot more information in the
 ### Is the fulfillment of the license key automated?
 
 Yes, license keys are issued automatically by our store software upon completion
-of the payment process.
+of the payment process. Sponsors can use their GitHub Sponsors account to log in
+to the store.
 
 ### Do license keys "phone home"?
 
@@ -296,23 +312,19 @@ abuse our trust.
 
 No. We run community support through our
 [Discord Server](https://discord.gg/graphile) where anyone can ask and answer
-questions about PostGraphile and the Graphile suite of tools. We offer a
-Development Support contract which includes async text support within your own
-Slack/GitHub organisation. Prices start at \$1,500 a month, with no minimum
-term. More information can be found at the
-[Development Support page](/support/).
+questions about PostGraphile and the Graphile suite of tools. Sponsors receive
+priority support from our maintainers within our Discord Server. Sponsors on the
+"Private Advisor" tier or above can enter a complimentary Development Support
+contract and receive support through their company Slack/GitHub organization.
+Prices start at \$1,500 a month, with no minimum term. More information can be
+found at the [Development Support page](https://graphile.org/support/) or you
+can
+[get in contract](mailto:info@graphile.org?subject=Private%20Advisor%20tier%20question).
 
 ### I'm an enterprise user and need X, Y and Z
 
 Please [get in touch](mailto:team@graphile.org?subject=Enterprise%20enquiry) and
 we'll be happy to help!
-
-### Commercial plugins help fund development on PostGraphile
-
-Maintaining an OSS project is very (very!) time-intensive. Giving this
-maintenance work a solid commercial backing benefits hobbyist and commercial
-users alike by making the project more sustainable and helping new features and
-fixes to be developed and released faster.
 
 </div>
 </div>

--- a/src/pages/postgraphile/pricing.md
+++ b/src/pages/postgraphile/pricing.md
@@ -48,22 +48,27 @@ any other benefit such as priority support or discounted consultancy rates.
   <thead>
 
 <tr>
-  <th></th>
+  <th rowspan="2"></th>
   <th><span class="f3 fab fa-github"></span> Core</th>
-  <th><span class='plan-pro'><span class='first-letter'>p</span></span> Pro</th>
+  <th><span class='plan-pro'><span class='first-letter'>p</span></span> License Only</th>
+  <th><span class='plan-sponsor'><span class='first-letter'>s</span></span> Production Sponsor</th>
+  <th><span class='plan-sponsor'><span class='first-letter'>s</span></span> Private Advisor Tier</th>
+</tr>
+
+<tr>
+  <th>OSS projects, not-for-profits</th>
+  <th>Small businesses</th>
+  <th>Small and medium businesses</th>
+  <th>Enterprise</th>
 </tr>
 
 </thead>
 <tbody>
 
 <tr>
-  <th>Audience</th>
-  <td>Hobbyists, OSS projects and<br />pre-revenue startups</td>
-  <td>Businesses and enterprise</td>
-</tr>
-
-<tr>
   <th>Instant GraphQL API<br />(queries and mutations)</th>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
 </tr>
@@ -72,10 +77,14 @@ any other benefit such as priority support or discounted consultancy rates.
   <th>Automatic CRUD mutations</th>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
 </tr>
 
 <tr>
   <th>Excellent performance</th>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
 </tr>
@@ -84,10 +93,14 @@ any other benefit such as priority support or discounted consultancy rates.
   <th>Authentication via JWT or custom <code>pgSettings</code></th>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
 </tr>
 
 <tr>
   <th>RLS and RBAC authorization</th>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
 </tr>
@@ -96,10 +109,14 @@ any other benefit such as priority support or discounted consultancy rates.
   <th>Relay-compatible connections</th>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
 </tr>
 
 <tr>
   <th>Simple list-based relations</th>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
 </tr>
@@ -108,10 +125,14 @@ any other benefit such as priority support or discounted consultancy rates.
   <th>Filtering</th>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
 </tr>
 
 <tr>
   <th>Ordering</th>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
 </tr>
@@ -120,10 +141,14 @@ any other benefit such as priority support or discounted consultancy rates.
   <th>Computed columns</th>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
 </tr>
 
 <tr>
   <th>Custom queries</th>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
 </tr>
@@ -132,28 +157,30 @@ any other benefit such as priority support or discounted consultancy rates.
   <th>Custom mutations</th>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
-</tr>
-
-<tr>
-  <th>Customisable with<br />Smart Comments</th>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
 </tr>
 
 <tr>
-  <th>Extensible via plugins</th>
+  <th>Smart Comments</th>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
 </tr>
 
 <tr>
-  <th>GraphQL <a href="/postgraphile/subscriptions/">Subscriptions</a></th>
+  <th>Plugins</th>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
 </tr>
 
 <tr>
-  <th>GraphQL <a href="/postgraphile/live-queries/">Live Queries</a></th>
+  <th>Real-time GraphQL</a></th>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
 </tr>
@@ -162,11 +189,15 @@ any other benefit such as priority support or discounted consultancy rates.
   <th>Integrated<sup>‡</sup> GraphQL query cost limit</th>
   <td><span class='fas fa-times-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
 </tr>
 
 <tr>
   <th>Integrated<sup>‡</sup> limits on pagination</th>
   <td><span class='fas fa-times-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
 </tr>
 
@@ -174,49 +205,90 @@ any other benefit such as priority support or discounted consultancy rates.
   <th>Integrated<sup>‡</sup> GraphQL query depth limits</th>
   <td><span class='fas fa-times-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
 </tr>
 
 <tr>
   <th>Facility to scale via read replicas</th>
   <td><span class='fas fa-times-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
+</tr>
+
+<tr>
+  <th>Free access to pgRITA</th>
+  <td><span class='fas fa-times-circle'></span></td>
+  <td><span class='fas fa-times-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
+</tr>
+
+<tr>
+  <th>Logo featured on website</th>
+  <td><span class='fas fa-times-circle'></span></td>
+  <td><span class='fas fa-times-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
+</tr>
+
+<tr>
+  <th>Logo featured in project</th>
+  <td><span class='fas fa-times-circle'></span></td>
+  <td><span class='fas fa-times-circle'></span></td>
+  <td><span class='fas fa-times-circle'></span></td>
+  <td><span class='fas fa-check-circle'></span></td>
+</tr>
+
+<tr>
+  <th>Sponsor's discount</th>
+  <td><span class='fas fa-times-circle'></span></td>
+  <td><span class='fas fa-times-circle'></span></td>
+  <td>Discounted video calls</td>
+  <td>Discounted consultancy packages</td>
+</tr>
+
+<tr>
+  <th>Support</th>
+  <td>via community Discord</td>
+  <td>via community Discord</td>
+  <td>Priority support via community Discord</td>
+  <td>Within your own company</td>
 </tr>
 
 <tr>
   <th>License</th>
   <td>MIT</td>
   <td>Commercial</td>
+  <td>Commercial</td>
+  <td>Commercial</td>
 </tr>
 
 <tr>
   <th>Pricing</th>
   <td><strong><a href='/sponsor/'>Crowd-funded</a></strong><span class='note'>Please give back</span></td>
-  <td><strong><small><s>$100/mo</s> USD</small> $25<small>/mo exc. VAT</small></strong><span class='note'><small>EUR €25/mo, GBP £20/mo</small></span></td>
+  <td><strong><small><s>$100/mo</s> USD</small> $25<small>/mo</small></strong><span class='note'><small>EUR €25/mo, GBP £20/mo excluding VAT</small></span></td>
+  <td><small>From</small> <strong>$100<small>/mo USD</small></strong><span class='note'><small>GitHub Sponsors or annual invoicing</small></span></td>
+    <td><small>From</small> <strong>$1,500<small>/mo USD</small></strong><span class='note'><small>GitHub Sponsors or bespoke invoicing</small></span></td>
 </tr>
 
-<tr>
-  <th>Purchase</th>
-  <td>&mdash;</td>
-  <td>Credit/Debit Card</td>
-</tr>
-
-  </tbody>
-  <tfoot>
+</tbody>
+<tfoot>
 
 <tr>
   <th></th>
-  <td><a class='button--solid' href='/sponsor/'>Sponsor development</span></a></td>
-  <td><a class='button--solid' href='https://store.graphile.com'>Buy <span class='fas fa-external-link-square-alt'></span></a></td>
+  <td></td>
+  <td><a class='button--outline' href='https://store.graphile.com'>Buy <span class='fas fa-external-link-square-alt'></span></a></td>
+  <td><a class='button--solid' href='https://github.com/sponsors/benjie'>Sponsor <span class='fas fa-external-link-square-alt'></span></a></td>
+  <td><a class='button--outline' href='mailto:info@graphile.org?subject=Private%20Advisor%20tier%20question'>Get in contact</a></td>
 </tr>
 
   </tfoot>
 
 </table>
 
-##### <sup>‡</sup> These features integrate deeply with PostGraphile and have been optimised for its nuances by the maintainer. If you wish to build and maintain protections yourself rather than using the Pro plugin, refer to [Running in Production](/postgraphile/production/) for information on how you might go about doing this. Purchasing the Pro plugin helps fund ongoing development and maintenance on the open source PostGraphile project.
-
-Questions, comments or feedback? Email
-<a href="mailto:info@graphile.org?subject=Pricing%20question/comment/feedback:)">info@graphile.org</a>
+##### <sup>‡</sup> These features integrate deeply with PostGraphile and have been optimized for its nuances by the maintainer. If you wish to build and maintain protections yourself rather than using the Pro plugin, refer to [Running in Production](/postgraphile/production/) for information on how you might go about doing this. Purchasing the Pro plugin helps fund ongoing development and maintenance on the open source PostGraphile project.
 
 </div>
 </div>

--- a/src/pages/postgraphile/pricing.md
+++ b/src/pages/postgraphile/pricing.md
@@ -32,11 +32,10 @@ title: PostGraphile Pro!
 
 ### How to get Pro
 
-PostGraphile Pro is available as a perk for
-[Graphile sponsors](https://graphile.org/sponsor/). Businesses which use
-PostGraphile should explore sponsorship as the first option to obtain Pro, as
-sponsorship also helps to fund development and maintenance of the Graphile
-suite, as well as enabling us to advance the software they rely on.
+PostGraphile Pro is available as a perk for [Graphile sponsors](/sponsor/).
+Businesses which use PostGraphile should explore sponsorship as the first option
+to obtain Pro, as sponsorship also helps to fund development and maintenance of
+the Graphile suite, as well as enabling us to advance the software they rely on.
 
 For businesses which are not capable of engaging in the sponsorship model, there
 is an option to purchase the license by itself. However, this does not come with
@@ -241,7 +240,7 @@ any other benefit such as priority support or discounted consultancy rates.
 </tr>
 
 <tr>
-  <th>Logo featured on <a href="https://graphile.org/sponsor">website</a></th>
+  <th>Logo featured on <a href="/sponsor">website</a></th>
   <td><span class='fas fa-times-circle'></span></td>
   <td><span class='fas fa-times-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>
@@ -449,8 +448,7 @@ priority support from our maintainers within our Discord Server. Sponsors on the
 "Private Advisor" tier or above can enter a complimentary Development Support
 contract and receive support through their company Slack/GitHub organization.
 Prices start at \$1,500 a month, with no minimum term. More information can be
-found at the [Development Support page](https://graphile.org/support/) or you
-can
+found at the [Development Support page](/support/) or you can
 [get in contract](mailto:info@graphile.org?subject=Private%20Advisor%20tier%20question).
 
 ### I'm an enterprise user and need X, Y and Z

--- a/src/pages/postgraphile/pricing.md
+++ b/src/pages/postgraphile/pricing.md
@@ -240,7 +240,7 @@ any other benefit such as priority support or discounted consultancy rates.
 </tr>
 
 <tr>
-  <th>Logo featured on <a href="/sponsor">website</a></th>
+  <th>Logo featured on <a href="/sponsor/">website</a></th>
   <td><span class='fas fa-times-circle'></span></td>
   <td><span class='fas fa-times-circle'></span></td>
   <td><span class='fas fa-check-circle'></span></td>

--- a/src/pages/postgraphile/production.md
+++ b/src/pages/postgraphile/production.md
@@ -237,9 +237,10 @@ their knees.
 
 **You are highly encouraged to purchase the
 [Pro Plugin [PRO]](/postgraphile/pricing/), which implements these protections
-in a deeply integrated and PostGraphile optimised way, and has the added benefit
-of helping sustain development and maintenance on the project.** You can read
-the [@graphile/pro README on npm](https://www.npmjs.com/package/@graphile/pro).
+in a deeply-integrated and PostGraphile-optimized way. Sponsors [SPON] also have
+access to the Pro Plugin and have the added benefit of helping sustain
+development and maintenance on the project.** You can read the
+[@graphile/pro README on npm](https://www.npmjs.com/package/@graphile/pro).
 
 The following details how the Pro Plugin addresses these issues, including hints
 on how you might go about solving the issues for yourself. Many of these
@@ -259,9 +260,10 @@ operations to read replicas (clones of your primary database)
   will perform any writes or not: if it's a `query` then it's read-only, if it's
   a `mutation` then it may perform writes.
 
-Using `--read-only-connection <string>` [PRO] you may give PostGraphile a
-separate connection string to use for queries, to compliment the connection
-string passed via `--connection` which will now be used only for mutations.
+Using `--read-only-connection <string>` [PRO]&nbsp;[SPON] you may give
+PostGraphile a separate connection string to use for queries, to compliment the
+connection string passed via `--connection` which will now be used only for
+mutations.
 
 (If you're using middleware, then you should use the `readOnlyConnection` option
 instead.)
@@ -275,13 +277,13 @@ instead.)
 It's unlikely that you want users to request `allUsers` and receive back
 literally all of the users in the database. More likely you want users to use
 cursor-based pagination over this connection with `first` / `after`. The Pro
-Plugin introduces the `--default-pagination-cap [int]` [PRO] option (library
-option: `defaultPaginationCap`) which enables you to enforce a pagination cap on
-all connections. Whatever number you pass will be used as the pagination cap
-(allowing requests smaller or equal to this cap to go through, and blocking
-those above it), but you can override it on a table-by-table basis using
-[smart comments](/postgraphile/smart-comments/) - in this case the
-`@paginationCap`[PRO] smart comment.
+Plugin introduces the `--default-pagination-cap [int]` [PRO]&nbsp;[SPON] option
+(library option: `defaultPaginationCap`) which enables you to enforce a
+pagination cap on all connections. Whatever number you pass will be used as the
+pagination cap (allowing requests smaller or equal to this cap to go through,
+and blocking those above it), but you can override it on a table-by-table basis
+using [smart comments](/postgraphile/smart-comments/) - in this case the
+`@paginationCap`[PRO]&nbsp;[SPON] smart comment.
 
 ```sql
 comment on table users is
@@ -292,18 +294,18 @@ comment on table users is
 
 Most GraphQL queries tend to be only a few levels deep, queries like the deep
 one at the top of this article are generally not required. You may use
-`--graphql-depth-limit [int]` [PRO] to limit the depth of any GraphQL queries
-that hit PostGraphile - any deeper than this will be discarded during query
-validation.
+`--graphql-depth-limit [int]` [PRO]&nbsp;[SPON] to limit the depth of any
+GraphQL queries that hit PostGraphile - any deeper than this will be discarded
+during query validation.
 
 #### [EXPERIMENTAL] GraphQL cost limit
 
 The most powerful way of preventing DOS is to limit the cost of GraphQL queries
 that may be executed against your GraphQL server. The Pro Plugin contains a
 early implementation of this technique with heuristically estimated costs. You
-may enable a cost limit with `--graphql-cost-limit [int]` [PRO] and the
-calculated cost of any GraphQL queries will be made available on `meta` field in
-the GraphQL payload.
+may enable a cost limit with `--graphql-cost-limit [int]` [PRO]&nbsp;[SPON] and
+the calculated cost of any GraphQL queries will be made available on `meta`
+field in the GraphQL payload.
 
 If your GraphQL query is seen to be too expensive, here's some techniques to
 bring the calculated cost down:

--- a/src/pages/postgraphile/usage-cli.md
+++ b/src/pages/postgraphile/usage-cli.md
@@ -232,17 +232,18 @@ please consider [sponsoring us](/sponsor/)!):
 The following features and not part of PostGraphile core, but are available from
 the Pro plugin - see [Go Pro!](/postgraphile/pricing/) for more information.
 
-- `--read-only-connection <string>` [PRO] ⚡️[experimental] a PostgreSQL
-  connection string to use for read-only queries (i.e. not mutations)
-- `--default-pagination-cap [int]` [PRO] ⚡️[experimental] Ensures all
-  connections have first/last specified and are no large than this value
+- `--read-only-connection <string>` [PRO]&nbsp;[SPON] ⚡️[experimental] a
+  PostgreSQL connection string to use for read-only queries (i.e. not mutations)
+- `--default-pagination-cap [int]` [PRO]&nbsp;[SPON] ⚡️[experimental] Ensures
+  all connections have first/last specified and are no large than this value
   (default: 50), set to -1 to disable; override via smart comment
   `@paginationCap 50`
-- `--graphql-depth-limit [int]` [PRO] ⚡️[experimental] Validates GraphQL
-  queries cannot be deeper than the specified int (default: 16), set to -1 to
-  disable
-- `--graphql-cost-limit [int]` [PRO] ⚡️[experimental] Only allows queries with
-  a computed cost below the specified int (default: 1000), set to -1 to disable
+- `--graphql-depth-limit [int]` [PRO]&nbsp;[SPON] ⚡️[experimental] Validates
+  GraphQL queries cannot be deeper than the specified int (default: 16), set to
+  -1 to disable
+- `--graphql-cost-limit [int]` [PRO]&nbsp;[SPON] ⚡️[experimental] Only allows
+  queries with a computed cost below the specified int (default: 1000), set to
+  -1 to disable
 
 ### RC file options
 

--- a/src/pages/postgraphile/usage-library.md
+++ b/src/pages/postgraphile/usage-library.md
@@ -534,20 +534,21 @@ The following options are not part of PostGraphile core, but are available from
 the Pro plugin - see [Go Pro!](/postgraphile/pricing/) for more information.
 
 - **`options`**:
-  - `readOnlyConnection` [PRO] ⚡️[experimental] set this to a PostgreSQL
-    connection string to use for read-only queries (i.e. not mutations)
-  - `defaultPaginationCap` [PRO] ⚡️[experimental] integer, ensure all
-    connections have first/last specified and are no large than this value
+  - `readOnlyConnection` [PRO]&nbsp;[SPON] ⚡️[experimental] set this to a
+    PostgreSQL connection string to use for read-only queries (i.e. not
+    mutations)
+  - `defaultPaginationCap` [PRO]&nbsp;[SPON] ⚡️[experimental] integer, ensure
+    all connections have first/last specified and are no large than this value
     (default: 50), set to -1 to disable; override via smart comment
     `@paginationCap 50`
-  - `graphqlDepthLimit` [PRO] ⚡️[experimental] integer, validate GraphQL
-    queries are no deeper than the specified int (default: 16), set to -1 to
-    disable
-  - `graphqlCostLimit` [PRO] ⚡️[experimental] integer, only allows queries with
-    a computed cost below the specified int (default: 1000), set to -1 to
-    disable
-  - `exposeGraphQLCost` [PRO] boolean, if true (default) then the calculated
-    query cost will be exposed on the resulting payload
+  - `graphqlDepthLimit` [PRO]&nbsp;[SPON] ⚡️[experimental] integer, validate
+    GraphQL queries are no deeper than the specified int (default: 16), set to
+    -1 to disable
+  - `graphqlCostLimit` [PRO]&nbsp;[SPON] ⚡️[experimental] integer, only allows
+    queries with a computed cost below the specified int (default: 1000), set to
+    -1 to disable
+  - `exposeGraphQLCost` [PRO]&nbsp;[SPON] boolean, if true (default) then the
+    calculated query cost will be exposed on the resulting payload
 
 ### Exposing HTTP request data to PostgreSQL
 

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -54,9 +54,14 @@ const Nav = ({ sections, pages, location }) => (
   </aside>
 );
 
-const tag = (name, label = name, noLink = false) =>
+const tag = (
+  name,
+  label = name,
+  noLink = false,
+  linkTarget = "/postgraphile/pricing/"
+) =>
   `<${
-    noLink ? "span" : "a href='/postgraphile/pricing/'"
+    noLink ? "span" : "a href='" + linkTarget + "'"
   } class="plan-${name}"><span class='first-letter'>${
     label[0]
   }</span><span class='rest'>${label.substr(1)}</span></${
@@ -65,6 +70,7 @@ const tag = (name, label = name, noLink = false) =>
 
 function processHTML(html, noLink) {
   return html
+    .replace(/\[SPON\]/g, tag("sponsor", "spon", noLink, "/sponsor/"))
     .replace(/\[SUPPORTER\]/g, tag("supporter", "supporter", noLink))
     .replace(/\[PRO\]/g, tag("pro", "pro", noLink))
     .replace(/\[ENTERPRISE\]/g, tag("enterprise", "enterprise", noLink))


### PR DESCRIPTION
<!-- Thank you for contributing to Graphile's Documentation! -->
An update to reflect the new Pro plan page at postgraphile.org (https://github.com/graphile/crystal/pull/1964)

- Add new columns for sponsorship
- Add new rows with sponsorship benefits
- Condense the table with tooltips
- New description at the top, as discussed previously
- Updated FAQ below to incorporate sponsorship
- Tweaks to the styling
- Implements a new SPON badge

~*EDIT* Argh I've just realised something is still missing, hold off a moment~


![Screenshot 2024-02-16 at 15 04 10](https://github.com/graphile/graphile.github.io/assets/6413628/1ff8298e-0ad0-404b-afd1-2138d08a83d7)
![Screenshot 2024-02-16 at 15 05 15](https://github.com/graphile/graphile.github.io/assets/6413628/5d7b81b0-a0ac-4a5a-828b-61cfcbb73711)
![Screenshot 2024-02-16 at 15 04 27](https://github.com/graphile/graphile.github.io/assets/6413628/657ee764-a687-4de0-a382-c011e2f1d974)

Made sure it works in the mobile view
![Screenshot 2024-02-16 at 15 04 56](https://github.com/graphile/graphile.github.io/assets/6413628/8848f41f-8c15-48d1-8882-49a67ad29f03)

New Sponsor badge added to the docs, it links to `/sponsor/`
![Screenshot 2024-02-16 at 16 23 14](https://github.com/graphile/graphile.github.io/assets/6413628/3c8dc02c-53d6-4b7b-9bb9-97a71848577f)



