### PR TITLE
Sponsor & Support pages update

### DIFF
--- a/src/components/Layout/index.scss
+++ b/src/components/Layout/index.scss
@@ -1119,3 +1119,16 @@ svg.MarketingDivide {
 .text-center2 {
   text-align: center;
 }
+
+// ----------------------------------------
+// Sponsor Page
+
+.tier-row {
+}
+
+.tier {
+}
+
+.tier a {
+  color: #4a68b4;
+}

--- a/src/components/MarketingTier.js
+++ b/src/components/MarketingTier.js
@@ -1,0 +1,56 @@
+import React from "react";
+
+export default function MarketingTiers({ children }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        gap: "1rem",
+        alignItems: "stretch",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export class Tier extends React.Component {
+  render() {
+    const { name, price, tagline, href, description } = this.props;
+
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          justifyItems: "space-between",
+          alignContent: "flex-start",
+          backgroundColor: "white",
+          margin: "0.5em",
+          padding: "1rem",
+          borderRadius: "12px",
+          border: "4px solid #1b1b3d",
+          color: "#1b3955",
+          flex: "0 0 33%",
+        }}
+      >
+        <h3>{name}</h3>
+        <span>
+          <span style={{ fontSize: "1.5rem" }}>{price}</span>{" "}
+          <span style={{ fontSize: "0.8rem" }}>/month</span>
+        </span>
+        <div class="tc">
+          <a class="button--solid" href={href}>
+            Join on GitHub Sponsors{" "}
+            <span class="fas fa-fw fa-external-link-square-alt" />
+          </a>
+        </div>
+        <h4>{tagline}</h4>
+        <div>
+          <span>{description}</span>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/MarketingTier.js
+++ b/src/components/MarketingTier.js
@@ -3,6 +3,7 @@ import React from "react";
 export default function MarketingTiers({ children }) {
   return (
     <div
+      className="tier-row"
       style={{
         display: "flex",
         flexDirection: "row",
@@ -21,6 +22,7 @@ export class Tier extends React.Component {
 
     return (
       <div
+        className="tier"
         style={{
           display: "flex",
           flexDirection: "column",
@@ -40,10 +42,10 @@ export class Tier extends React.Component {
           <span style={{ fontSize: "1.5rem" }}>{price}</span>{" "}
           <span style={{ fontSize: "0.8rem" }}>/month</span>
         </span>
-        <div class="tc">
-          <a class="button--solid" href={href}>
+        <div className="tc">
+          <a className="button--solid" href={href}>
             Join on GitHub Sponsors{" "}
-            <span class="fas fa-fw fa-external-link-square-alt" />
+            <span className="fas fa-fw fa-external-link-square-alt" />
           </a>
         </div>
         <h4>{tagline}</h4>

--- a/src/pages/sponsor.mdx
+++ b/src/pages/sponsor.mdx
@@ -16,6 +16,7 @@ import MarketingProduct from "$components/MarketingProduct";
 import postgresPostgraphileGraphql from "$images/postgres_postgraphile_graphql.png";
 import Testimonial from "$components/MarketingTestimonial";
 import Sponsors, { Sponsor } from "$components/MarketingSponsor";
+import Tiers, { Tier } from "$components/MarketingTier";
 
 <MarketingLayout blue>
 <Hero bg="medium">
@@ -215,20 +216,98 @@ directed and financially sustainable.
 to come is through monthly sponsorship.** Crowd-sourced funding enables us to spend the 
 most time directly working on improving the software, which you and other users then benefit from.
 
-<div class="flex">
-  <a class="button--solid" href="https://github.com/users/benjie/sponsorship">
-    Become a Sponsor <span class="fas fa-fw fa-external-link-square-alt" />
-  </a>
-</div>
-
 </MarketingSection>
 <MarketingDivide from="dark" to="medium" via="light" down/>
 <MarketingSection bg="medium" left maxWidth>
 
-
 ### Sponsor tiers and benefits
 
+As well as ensuring the sustainability and longevity of PostGraphile and the wider Graphile
+suite of developer tooling, sponsorship also gives you or your company some additional benefits
+such as access to security announcements and being featured in the README files of Graphile’s
+main open source projects. Choose the tier which matches your funding goal, higher tiers come
+with more benefits.
 
+</MarketingSection>
+
+<MarketingSection bg="medium" left>
+
+<Tiers>
+  <Tier 
+    name="Supporter"
+    price="$25"
+    tagline="Thank you!"
+    href="https://github.com/sponsors/benjie/sponsorships?tier_id=369"
+    description={<ul>
+          <li>Your name on the Graphile Sponsors page</li>
+          <li>Graphile stickers</li>
+          <li>Your name among those randomly featured in the PostGraphile CLI</li>
+          <li>Post job opportunities to our Discord community</li>
+          <li>Access to the #supporter-lounge on Discord</li>
+          <li>The warm feeling from knowing you’re supporting Open Source Software</li>
+        </ul>}
+  />
+  <Tier 
+    name="Production Sponsor" 
+    price="$100" 
+    tagline="Support sustainability"
+    href="https://github.com/sponsors/benjie/sponsorships?tier_id=368"
+    description={<ul>
+          <li>The Supporter tier benefits and...</li>
+          <li>
+            Access to <strong>private security announcements</strong>
+          </li>
+          <li>
+            Free access to <a href="https://postgraphile.org/pricing"><strong>PostGraphile V4 Pro</strong></a> and <a href="https://worker.graphile.org/pricing"><strong>Worker Pro</strong></a>
+          </li>
+          <li>Access to <a href="https://github.com/graphile-pro"><strong>graphile-pro</strong></a></li>
+          <li>
+            Your name and <strong>avatar/logo</strong> featured on our websites
+          </li>
+          <li>
+            Your name <strong>more frequently featured</strong> in the
+            PostGraphile CLI
+          </li>
+          <li>
+            The warm feeling that comes from knowing you’re making a difference
+            to the sustainability of the Graphile suite of tooling
+          </li>
+        </ul>}
+  />
+  <Tier 
+    name="Featured Sponsor" 
+    price="$500" 
+    tagline="Get featured in the project"
+    href="https://github.com/sponsors/benjie/sponsorships?tier_id=367"
+    description={<ul>
+          <li>The Production tier benefits and...</li>
+          <li>
+            Your name and avatar/logo <strong>
+              featured in the READMEs of Graphile’s main OSS projects</strong> (shown on GitHub and npm)
+          </li>
+          <li>
+            Your name and <strong>avatar/logo prominently featured </strong>on our websites
+          </li>
+          <li>
+            Your name <strong>even more frequently featured</strong> in the PostGraphile CLI
+          </li>
+          <li>
+            Access to <strong>#vip-lounge</strong> on Discord
+          </li>
+          <li>
+            Free access to <strong>
+              <a href="https://pgrita.com">pgRITA</a>
+            </strong>
+          </li>
+          <li>
+            The warm feeling that comes from knowing{" "}
+            <strong>
+              you’re making a significant difference to the development and sustainability of
+              PostGraphile, Gra<em>fast</em>, and the wider suite of Graphile developer tooling</strong>
+          </li>
+        </ul>}
+  />
+</Tiers>
 
 
 

--- a/src/pages/sponsor.mdx
+++ b/src/pages/sponsor.mdx
@@ -20,7 +20,7 @@ import Sponsors, { Sponsor } from "$components/MarketingSponsor";
 <MarketingLayout blue>
 <Hero bg="medium">
 
-# Sponsor Graphile's Open Source Software
+# Sponsor Graphile’s Open Source Software
 
 </Hero>
 
@@ -30,7 +30,7 @@ import Sponsors, { Sponsor } from "$components/MarketingSponsor";
 
 <div style={{maxWidth: '48rem', margin: '0 auto'}}>
 
-We're extremely grateful to the following individuals and businesses that help
+We’re extremely grateful to the following individuals and businesses that help
 to fund ongoing development on the Graphile suite through sponsorship. **THANK
 YOU!**
 
@@ -143,7 +143,7 @@ YOU!**
 
 <div class="flex">
   <a class="button--solid" href="https://github.com/users/benjie/sponsorship">
-    Sponsor Graphile's Open Source Software{" "}
+    Sponsor Graphile’s Open Source Software{" "}
     <span class="fas fa-fw fa-external-link-square-alt" />
   </a>
 </div>
@@ -203,7 +203,7 @@ advancement without adding additional time burdens.
 
 <MarketingSection bg="dark" left maxWidth>
 
-### Why "crowd-funded open-source project"?
+### Why “crowd-funded open-source project”?
 
 Many of our projects are open-source to give users great freedom in how they use
 the software, and to enable the community to have influence over how the
@@ -211,9 +211,9 @@ projects progress to make it appropriate for a wide range of use-cases. To
 ensure users can rely on these projects for years to come, they need to be well
 directed and financially sustainable.
 
-**The absolute best way to support Graphile is to become a sponsor.**
-Crowd-sourced funding enables us to spend the most time directly working on
-improving the software, which you and other users then benefit from.
+**The best way to ensure that Graphile software is something you can depend on for years
+to come is through monthly sponsorship.** Crowd-sourced funding enables us to spend the 
+most time directly working on improving the software, which you and other users then benefit from.
 
 <div class="flex">
   <a class="button--solid" href="https://github.com/users/benjie/sponsorship">
@@ -222,8 +222,22 @@ improving the software, which you and other users then benefit from.
 </div>
 
 </MarketingSection>
-<MarketingDivide from="dark" to="medium" />
+<MarketingDivide from="dark" to="medium" via="light" down/>
 <MarketingSection bg="medium" left maxWidth>
+
+
+### Sponsor tiers and benefits
+
+
+
+
+
+
+
+</MarketingSection>
+<MarketingDivide from="medium" to="dark" via="light" down/>
+<MarketingSection bg="dark" left maxWidth>
+
 
 ### How is sponsorship money spent?
 
@@ -232,10 +246,10 @@ and releases of PostGraphile and the Graphile suite. A small amount is also used
 to send rewards such as stickers and learning materials to our backers.
 
 </MarketingSection>
-<MarketingDivide from="medium" to="dark" down />
-<MarketingSection bg="dark" left maxWidth>
+<MarketingDivide from="dark" to="medium" down />
+<MarketingSection bg="medium" left maxWidth>
 
-### Is sponsorship required to use Graphile's OSS?
+### Is sponsorship required to use Graphile’s OSS?
 
 Users are not legally required to give back to the Graphile project, but it is
 in their interest to do so.
@@ -247,8 +261,8 @@ savings back, enabling the projects to advance more rapidly, and result in even
 greater savings for your organization.
 
 </MarketingSection>
-<MarketingDivide from="dark" to="medium" via="light" />
-<MarketingSection bg="medium" left maxWidth>
+<MarketingDivide from="medium" to="dark" via="light" />
+<MarketingSection bg="dark" left maxWidth>
 
 ### How can I sponsor?
 

--- a/src/pages/support/index.mdx
+++ b/src/pages/support/index.mdx
@@ -40,7 +40,7 @@ import TeamBio from '$components/MarketingTeamBio';
 <MarketingBullets single big bullets={[
 "One-on-one time with Graphile's maintainer",
 'Same-day slots often available',
-'One hour of voice / screensharing for $500',
+'One hour of voice / screensharing for $375',
 'Book directly from the calendar using a credit or debit card',
 ]}/>
 
@@ -79,27 +79,27 @@ import TeamBio from '$components/MarketingTeamBio';
 
 </MarketingSection>
 
-<MarketingDivide from="nodes" to="medium" />
+<MarketingDivide from="nodes" to="dark" />
 
-<MarketingSection bg="medium">
+<MarketingSection bg="dark">
 
 <div className="f4 tl" style={{maxWidth: '50rem', margin: '0 auto'}}>
-Development Support gives your organisation access to the knowledge and
+Development Support gives your organization access to the knowledge and
 experience of the Graphile team for any issues you have with
 PostGraphile, the Graphile suite and other tools in the ecosystem 
 such as TypeScript, SQL, Node.js, GraphQL and more. If you're
 running any of the Graphile tools, you won't find anyone more qualified
 to help.
 
-From $1,500/month, paid monthly through GitHub sponsors, or
+From $999/month, paid monthly through GitHub sponsors, or
 quarterly/annually through invoicing (+ VAT where applicable). T&Cs apply.
 </div>
 
 </MarketingSection>
 
-<MarketingDivide from="medium" to="dark" via="light" down/>
+<MarketingDivide from="dark" to="medium" via="light" down/>
 
-<MarketingSection bg="dark">
+<MarketingSection bg="medium">
 
 <div className="f4 b tl" style={{maxWidth: '54rem', margin: '0 auto'}}>
 <div class="mw9 ph3-ns flex flex-wrap justify-between">
@@ -119,42 +119,7 @@ for faster, safer and more robust software development and practices.
 
 </MarketingSection>
 
-<MarketingDivide from="dark" to="nodes" via="light"/>
-
-<MarketingSection bg="nodes">
-
-<div className="f4 tl" style={{maxWidth: '50rem', margin: '0 auto'}}>
-
-## Want more?
-
-### Our Consultancy Retainer includes the benefits above, plus:
-
-<MarketingBullets single big bullets={[
-'Schedule calls directly on our calendar, no additional fee',
-<>Longer and deeper discussions:<ul className="ul-check">
-<li>planning product features</li>
-    <li>designing your database or GraphQL schema</li>
-    <li>solving (or avoiding) performance issues</li>
-    <li>debugging</li></ul></>,
-'Targeted code review'
-]}/>
-
-<div className="f4 tl" style={{maxWidth: '50rem', margin: '0 auto'}}>
-From $6,000/month, cancel any time, no minimum term.
-
-</div>
-
-<p class='flex'>
-<a class='button--solid' href='mailto:team@graphile.com?subject=Support%20plan%20enquiry'>Get in touch <span class='fas fa-fw fa-arrow-right' /></a>
-</p>
-
-*T&Cs apply - calls may be up to 3 hours, at most one per day, subject to availability -
-prices quoted for teams containing up to 10 engineers - pay monthly through GitHub Sponsors, or through
-quarterly/annual invoicing (+ VAT where applicable).*
-</div>
-</MarketingSection>
-
-<MarketingDivide from="nodes" to="dark" via="light"/>
+<MarketingDivide from="medium" to="dark" via="light"/>
 
 <MarketingSection bg="dark">
 


### PR DESCRIPTION
<!-- Thank you for contributing to Graphile's Documentation! -->

I've updated the Sponsor and Support pages to reflect changes made in
https://github.com/graphile/crystal/pull/2615
https://github.com/graphile/worker/pull/549

But I am stuck on how to do the responsiveness. I'm probably missing something fundamental, but it's been ages since I've tinkered with the styling of this website. 

<img width="1875" height="1288" alt="Screenshot 2025-07-25 at 12 55 47" src="https://github.com/user-attachments/assets/e3edfd6c-fa0e-4842-a29e-e1c6c074e739" />

